### PR TITLE
Fix completion command authentication requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Completion command authentication**: Removed authentication requirement for `completion` command and its subcommands (bash, zsh, fish, powershell)
+
 ## v0.4.2 - 2025-07-30
 
 ### Added

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,13 @@ The following commands are currently supported:
 - tail: Provide a live 'tail' of a log`,
 	Version: app.Version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Skip authentication for commands that don't need API access
+		// Check both the command itself and its parent (for completion subcommands like "bash", "zsh", etc.)
+		if cmd.Name() == "completion" || cmd.Name() == "help" ||
+			(cmd.Parent() != nil && cmd.Parent().Name() == "completion") {
+			return nil
+		}
+
 		var err error
 		cfg, err = config.New()
 		if err != nil {


### PR DESCRIPTION
## Summary
- Removed authentication requirement for `completion` command and its subcommands (bash, zsh, fish, powershell)
- Modified `PersistentPreRunE` in root command to skip auth validation for completion-related commands
- Added CHANGELOG entry

## Changes
- Updated `internal/cli/root.go` to check command name/parent before validating authentication
- Updated `CHANGELOG.md` under [Unreleased] section

## Test Plan
- [x] Verified `logbasset completion bash` works without API token
- [x] Verified `logbasset completion zsh` works without API token
- [x] Verified `logbasset completion fish` works without API token
- [x] Verified API commands (query, tail, power-query) still require authentication
- [x] Updated CHANGELOG.md

## Fixes
Closes #20