### PR TITLE
Fix --token flag not being applied before validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **CLI flag parsing**: Fixed `--token` flag not being applied before validation, causing authentication errors even when token was provided via command line
+
 ## v0.4.3 - 2025-11-05
 
 ### Fixed

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,7 +40,7 @@ The following commands are currently supported:
 		}
 
 		var err error
-		cfg, err = config.New()
+		cfg, err = config.NewWithoutValidation()
 		if err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	LogLevel string `mapstructure:"log_level"`
 }
 
-func New() (*Config, error) {
+func NewWithoutValidation() (*Config, error) {
 	v := viper.New()
 
 	setDefaults(v)
@@ -32,6 +32,15 @@ func New() (*Config, error) {
 	config := &Config{}
 	if err := v.Unmarshal(config); err != nil {
 		return nil, errors.NewConfigError("failed to unmarshal configuration", err)
+	}
+
+	return config, nil
+}
+
+func New() (*Config, error) {
+	config, err := NewWithoutValidation()
+	if err != nil {
+		return nil, err
 	}
 
 	if err := validateConfig(config); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,57 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewWithoutValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		envVars      map[string]string
+		expectError  bool
+		expectToken  string
+		expectServer string
+	}{
+		{
+			name: "creates config with token without validation",
+			envVars: map[string]string{
+				"scalyr_readlog_token": "test-token",
+			},
+			expectError:  false,
+			expectToken:  "test-token",
+			expectServer: "https://www.scalyr.com",
+		},
+		{
+			name:         "creates config without token - no validation error",
+			envVars:      map[string]string{},
+			expectError:  false,
+			expectToken:  "",
+			expectServer: "https://www.scalyr.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv()
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			defer clearEnv()
+
+			config, err := NewWithoutValidation()
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, config)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, config)
+				assert.Equal(t, tt.expectToken, config.Token)
+				assert.Equal(t, tt.expectServer, config.Server)
+				assert.Equal(t, "high", config.Priority)
+				assert.False(t, config.Verbose)
+			}
+		})
+	}
+}
+
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -165,6 +216,49 @@ func TestSetFromFlags(t *testing.T) {
 	assert.True(t, config.Verbose)
 	assert.Equal(t, "low", config.Priority)
 	assert.Equal(t, "debug", config.LogLevel)
+}
+
+func TestFlagOverrideFlow(t *testing.T) {
+	clearEnv()
+	defer clearEnv()
+
+	// Simulate CLI flow: create config without token, then set from flag
+	config, err := NewWithoutValidation()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, "", config.Token)
+
+	// Validation should fail without token
+	err = config.Validate()
+	assert.Error(t, err)
+
+	// Apply flag values
+	config.SetFromFlags("flag-token", "", false, "", "")
+
+	// Validation should now pass
+	err = config.Validate()
+	assert.NoError(t, err)
+	assert.Equal(t, "flag-token", config.Token)
+}
+
+func TestFlagOverrideEnv(t *testing.T) {
+	clearEnv()
+	os.Setenv("scalyr_readlog_token", "env-token")
+	defer clearEnv()
+
+	// Create config with env token
+	config, err := NewWithoutValidation()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, "env-token", config.Token)
+
+	// Flag should override env
+	config.SetFromFlags("flag-token", "", false, "", "")
+	assert.Equal(t, "flag-token", config.Token)
+
+	// Validation should pass
+	err = config.Validate()
+	assert.NoError(t, err)
 }
 
 func clearEnv() {


### PR DESCRIPTION
## Summary
- Fixes #21 by ensuring CLI flags are applied before configuration validation
- Refactored config initialization to separate creation from validation

## Changes
- Added `NewWithoutValidation()` function in config package to allow flag application before validation
- Updated `root.go` to validate config after `SetFromFlags()` is called
- Added comprehensive tests for flag override behavior including `TestFlagOverrideFlow()` and `TestFlagOverrideEnv()`

## Testing
- All existing tests pass
- New tests verify flag override functionality works correctly
- Build succeeds without issues