### PR TITLE
Fix pagination DuplicateEliminationFailed error with continuationToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Pagination with continuationToken**: Fixed "DuplicateEliminationFailed" error when using continuationToken in tail command by creating clean parameter maps that exclude conflicting parameters like pageMode and filter
+
 ## v0.4.4 - 2025-11-05
 
 ### Fixed


### PR DESCRIPTION
## Summary
Fixes the "DuplicateEliminationFailed after attempts=2" error that occurs when using continuationToken for pagination in the tail command.

## Problem
The pagination loop was reusing the original `requestParams` map and simply adding `continuationToken` to it. This meant subsequent requests sent BOTH `pageMode: "tail"` AND `continuationToken`, which creates a conflict that causes the Scalyr API to fail with duplicate elimination errors.

## Solution
Modified `internal/client/tail.go` to create a fresh `continuationParams` map for pagination requests that only includes:
- `queryType: "log"`
- `continuationToken` (from previous response)
- `maxCount: 1000`
- `priority` (if specified)

And explicitly **excludes**: `pageMode` and `filter` (these are already encapsulated in the continuation token)

## Changes
- Modified pagination loop in `internal/client/tail.go`
- Added comprehensive test `TestTail_PaginationParameters` to verify correct parameters in both initial and continuation requests
- Updated CHANGELOG.md

## Testing
- ✅ All existing tests pass
- ✅ New test validates correct parameter separation
- ✅ Verified with real Scalyr API - pagination works without errors
- ✅ Tested multiple continuation requests (4+ requests over 10 seconds)

## Verification
Real API test showed:
- Request 1: Has `pageMode: "tail"`, NO `continuationToken` ✅
- Requests 2-4: Have `continuationToken`, NO `pageMode` or `filter` ✅
- All requests succeeded without "DuplicateEliminationFailed" errors ✅