### PR TITLE
Make logbasset agent-friendly for AI/LLM consumption

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,120 @@
+# LogBasset - Agent Context
+
+LogBasset is a **read-only** CLI for querying Scalyr/DataSet logs. All commands are queries; nothing is mutated.
+
+## Authentication
+
+Set the API token via:
+- Environment variable: `scalyr_readlog_token`
+- Config file key: `token`
+- Flag: `--token`
+
+Server URL (default `https://www.scalyr.com`):
+- Environment variable: `scalyr_server`
+- Config file key: `server`
+- Flag: `--server`
+
+## Commands
+
+| Command | Description | Required args | Required flags |
+|---------|-------------|---------------|----------------|
+| `query [filter]` | Retrieve log data | none (filter optional) | none |
+| `power-query <query>` | Execute PowerQuery | query (positional) | `--start` |
+| `numeric-query [filter]` | Retrieve numeric/graph data | none (filter optional) | `--start` |
+| `facet-query <filter> <field>` | Get common values for a field | filter, field (positional) | `--start` |
+| `timeseries-query [filter]` | Retrieve timeseries data | none (filter optional) | `--start` |
+| `tail [filter]` | Live tail of logs | none (filter optional) | none |
+| `context` | Print this agent context document | none | none |
+| `schema [command]` | Print JSON schema for command inputs/outputs | none | none |
+
+## Global Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--token` | string | (env) | API token |
+| `--server` | string | `https://www.scalyr.com` | Server URL |
+| `--verbose` | bool | false | Enable verbose output |
+| `--priority` | string | `high` | Query priority: `high` or `low` |
+| `--log-level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
+| `--error-format` | string | `text` | Error output format: `text` or `json` |
+
+## Flags That Do NOT Exist
+
+Agents commonly hallucinate these flags. They will cause errors:
+- `--env` — does not exist
+- `--minutes` — use `--start "30m"` instead
+- `--query` — pass query as positional argument
+- `--format` — use `--output` instead
+- `--limit` — use `--count` instead
+- `--from` / `--to` — use `--start` / `--end` instead
+
+## Time Format Reference
+
+- Relative: `30m`, `1h`, `24h`, `7d` (minutes, hours, days)
+- Absolute: `2024-01-15`, `2024-01-15 14:30:05`
+- Time-only: `14:30`, `2:30 PM`
+- Special: `NOW` (for `--end` to get results up to current time)
+
+When using `--start` without `--end`, the API returns only 24h from start. Use `--end NOW` to get results up to the current time.
+
+## Output Formats
+
+### query command
+`--output`: `multiline` (default in TTY), `singleline`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+
+### power-query, numeric-query, facet-query, timeseries-query
+`--output`: `csv` (default in TTY), `json` (default in pipe), `json-pretty`
+
+### tail command
+`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `json` (default in pipe)
+
+Use `--fields` with `query --output json` to select specific fields and reduce output size.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General/API/parse error |
+| 2 | Usage error (bad command syntax) |
+| 3 | Network error |
+| 4 | Authentication error (bad/missing token) |
+| 5 | Configuration error |
+| 6 | Validation error (bad input) |
+
+## Structured Error Output
+
+Use `--error-format json` to get machine-readable errors on stderr:
+```json
+{"error":{"type":"AUTH_ERROR","message":"API token is required","suggestion":"...","exit_code":4}}
+```
+
+## TTY Auto-Detection
+
+When stdout is not a TTY (piped to another program), the default output format automatically switches to `json`. This can be overridden with an explicit `--output` flag.
+
+## Examples
+
+```bash
+# Search logs for errors in the last hour
+logbasset query 'severity="error"' --start "1h" --count 100 --output json
+
+# Search with text filter, get JSON output with specific fields
+logbasset query '"service timeout"' --start "24h" --output json --fields timestamp,message,severity
+
+# PowerQuery: count errors by server
+logbasset power-query 'serverHost = * | group count by serverHost' --start "1h" --output json
+
+# Facet query: top URLs
+logbasset facet-query '*' 'url' --start "24h" --count 50 --output json
+
+# Numeric query: error rate over 24h in hourly buckets
+logbasset numeric-query 'severity="error"' --function 'count' --start "24h" --buckets 24 --output json
+
+# Tail with JSON for agent consumption
+logbasset tail 'severity="error"' --output json --lines 50
+
+# Get structured errors for programmatic handling
+logbasset query '"test"' --error-format json 2>/tmp/err.json
+```

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed context_embed.md
+var contextContent string
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Print agent context document for AI/LLM consumption",
+	Long:  "Prints a structured reference document describing LogBasset's commands, flags, output formats, and usage patterns. Useful for AI agents and automation tools.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Print(contextContent)
+	},
+}

--- a/internal/cli/context_embed.md
+++ b/internal/cli/context_embed.md
@@ -1,0 +1,120 @@
+# LogBasset - Agent Context
+
+LogBasset is a **read-only** CLI for querying Scalyr/DataSet logs. All commands are queries; nothing is mutated.
+
+## Authentication
+
+Set the API token via:
+- Environment variable: `scalyr_readlog_token`
+- Config file key: `token`
+- Flag: `--token`
+
+Server URL (default `https://www.scalyr.com`):
+- Environment variable: `scalyr_server`
+- Config file key: `server`
+- Flag: `--server`
+
+## Commands
+
+| Command | Description | Required args | Required flags |
+|---------|-------------|---------------|----------------|
+| `query [filter]` | Retrieve log data | none (filter optional) | none |
+| `power-query <query>` | Execute PowerQuery | query (positional) | `--start` |
+| `numeric-query [filter]` | Retrieve numeric/graph data | none (filter optional) | `--start` |
+| `facet-query <filter> <field>` | Get common values for a field | filter, field (positional) | `--start` |
+| `timeseries-query [filter]` | Retrieve timeseries data | none (filter optional) | `--start` |
+| `tail [filter]` | Live tail of logs | none (filter optional) | none |
+| `context` | Print this agent context document | none | none |
+| `schema [command]` | Print JSON schema for command inputs/outputs | none | none |
+
+## Global Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--token` | string | (env) | API token |
+| `--server` | string | `https://www.scalyr.com` | Server URL |
+| `--verbose` | bool | false | Enable verbose output |
+| `--priority` | string | `high` | Query priority: `high` or `low` |
+| `--log-level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
+| `--error-format` | string | `text` | Error output format: `text` or `json` |
+
+## Flags That Do NOT Exist
+
+Agents commonly hallucinate these flags. They will cause errors:
+- `--env` — does not exist
+- `--minutes` — use `--start "30m"` instead
+- `--query` — pass query as positional argument
+- `--format` — use `--output` instead
+- `--limit` — use `--count` instead
+- `--from` / `--to` — use `--start` / `--end` instead
+
+## Time Format Reference
+
+- Relative: `30m`, `1h`, `24h`, `7d` (minutes, hours, days)
+- Absolute: `2024-01-15`, `2024-01-15 14:30:05`
+- Time-only: `14:30`, `2:30 PM`
+- Special: `NOW` (for `--end` to get results up to current time)
+
+When using `--start` without `--end`, the API returns only 24h from start. Use `--end NOW` to get results up to the current time.
+
+## Output Formats
+
+### query command
+`--output`: `multiline` (default in TTY), `singleline`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+
+### power-query, numeric-query, facet-query, timeseries-query
+`--output`: `csv` (default in TTY), `json` (default in pipe), `json-pretty`
+
+### tail command
+`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `json` (default in pipe)
+
+Use `--fields` with `query --output json` to select specific fields and reduce output size.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General/API/parse error |
+| 2 | Usage error (bad command syntax) |
+| 3 | Network error |
+| 4 | Authentication error (bad/missing token) |
+| 5 | Configuration error |
+| 6 | Validation error (bad input) |
+
+## Structured Error Output
+
+Use `--error-format json` to get machine-readable errors on stderr:
+```json
+{"error":{"type":"AUTH_ERROR","message":"API token is required","suggestion":"...","exit_code":4}}
+```
+
+## TTY Auto-Detection
+
+When stdout is not a TTY (piped to another program), the default output format automatically switches to `json`. This can be overridden with an explicit `--output` flag.
+
+## Examples
+
+```bash
+# Search logs for errors in the last hour
+logbasset query 'severity="error"' --start "1h" --count 100 --output json
+
+# Search with text filter, get JSON output with specific fields
+logbasset query '"service timeout"' --start "24h" --output json --fields timestamp,message,severity
+
+# PowerQuery: count errors by server
+logbasset power-query 'serverHost = * | group count by serverHost' --start "1h" --output json
+
+# Facet query: top URLs
+logbasset facet-query '*' 'url' --start "24h" --count 50 --output json
+
+# Numeric query: error rate over 24h in hourly buckets
+logbasset numeric-query 'severity="error"' --function 'count' --start "24h" --buckets 24 --output json
+
+# Tail with JSON for agent consumption
+logbasset tail 'severity="error"' --output json --lines 50
+
+# Get structured errors for programmatic handling
+logbasset query '"test"' --error-format json 2>/tmp/err.json
+```

--- a/internal/cli/facet_query.go
+++ b/internal/cli/facet_query.go
@@ -92,6 +92,11 @@ func runFacetQuery(cmd *cobra.Command, args []string) {
 		errors.HandleErrorAndExit(err)
 	}
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		facetQueryOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	switch facetQueryOutput {
 	case "json":
 		outputJSON(result, false)

--- a/internal/cli/numeric_query.go
+++ b/internal/cli/numeric_query.go
@@ -96,6 +96,11 @@ func runNumericQuery(cmd *cobra.Command, args []string) {
 		errors.HandleErrorAndExit(err)
 	}
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		numericQueryOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	switch numericQueryOutput {
 	case "json":
 		outputJSON(result, false)

--- a/internal/cli/power_query.go
+++ b/internal/cli/power_query.go
@@ -85,6 +85,11 @@ func runPowerQuery(cmd *cobra.Command, args []string) {
 		errors.HandleErrorAndExit(err)
 	}
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		powerQueryOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	switch powerQueryOutput {
 	case "json":
 		outputJSON(result, false)

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/andreagrandi/logbasset/internal/client"
 	"github.com/andreagrandi/logbasset/internal/errors"
+	"github.com/andreagrandi/logbasset/internal/logging"
 	"github.com/andreagrandi/logbasset/internal/validation"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,7 @@ var (
 	queryMode      string
 	queryColumns   string
 	queryOutput    string
+	queryFields    string
 )
 
 func init() {
@@ -42,6 +44,7 @@ func init() {
 	queryCmd.Flags().StringVar(&queryMode, "mode", "", "Display mode: head or tail")
 	queryCmd.Flags().StringVar(&queryColumns, "columns", "", "Comma-separated list of columns to display")
 	queryCmd.Flags().StringVar(&queryOutput, "output", "multiline", "Output format: multiline|singleline|csv|json|json-pretty")
+	queryCmd.Flags().StringVar(&queryFields, "fields", "", "Comma-separated fields to include in JSON output (e.g., timestamp,message,severity)")
 }
 
 func runQuery(cmd *cobra.Command, args []string) {
@@ -66,6 +69,12 @@ func runQuery(cmd *cobra.Command, args []string) {
 
 	if err := validation.ValidateQueryParams(params, validationConfig); err != nil {
 		errors.HandleErrorAndExit(err)
+	}
+
+	if queryFields != "" {
+		if err := validation.ValidateFields(queryFields); err != nil {
+			errors.HandleErrorAndExit(err)
+		}
 	}
 
 	c := getConfig().GetClient()
@@ -98,18 +107,81 @@ func runQuery(cmd *cobra.Command, args []string) {
 		errors.HandleErrorAndExit(err)
 	}
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		queryOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	switch queryOutput {
 	case "json":
-		outputJSON(result, false)
+		if queryFields != "" {
+			outputFilteredJSON(result.Matches, queryFields, false)
+		} else {
+			outputJSON(result, false)
+		}
 	case "json-pretty":
-		outputJSON(result, true)
+		if queryFields != "" {
+			outputFilteredJSON(result.Matches, queryFields, true)
+		} else {
+			outputJSON(result, true)
+		}
 	case "csv":
+		if queryFields != "" {
+			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
+		}
 		outputCSV(result.Matches, queryColumns)
 	case "singleline":
+		if queryFields != "" {
+			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
+		}
 		outputSingleLine(result.Matches)
 	default:
+		if queryFields != "" {
+			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
+		}
 		outputMultiLine(result.Matches)
 	}
+}
+
+func outputFilteredJSON(events []client.LogEvent, fields string, pretty bool) {
+	fieldList := strings.Split(fields, ",")
+	for i, f := range fieldList {
+		fieldList[i] = strings.TrimSpace(f)
+	}
+
+	fieldSet := make(map[string]bool, len(fieldList))
+	for _, f := range fieldList {
+		fieldSet[f] = true
+	}
+
+	var filtered []map[string]interface{}
+	for _, event := range events {
+		m := make(map[string]interface{})
+		if fieldSet["timestamp"] {
+			m["timestamp"] = event.Timestamp
+		}
+		if fieldSet["severity"] {
+			m["severity"] = event.Severity
+		}
+		if fieldSet["message"] {
+			m["message"] = event.Message
+		}
+		if fieldSet["thread"] {
+			m["thread"] = event.Thread
+		}
+		// Check attribute keys
+		for _, f := range fieldList {
+			if f == "timestamp" || f == "severity" || f == "message" || f == "thread" {
+				continue
+			}
+			if val, ok := event.Attributes[f]; ok {
+				m[f] = val
+			}
+		}
+		filtered = append(filtered, m)
+	}
+
+	outputJSON(filtered, pretty)
 }
 
 func outputJSON(data any, pretty bool) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,17 +5,19 @@ import (
 
 	"github.com/andreagrandi/logbasset/internal/app"
 	"github.com/andreagrandi/logbasset/internal/config"
+	"github.com/andreagrandi/logbasset/internal/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
-	cfg          *config.Config
-	flagToken    string
-	flagServer   string
-	flagVerbose  bool
-	flagPriority string
-	flagLogLevel string
-	flagTimeout  time.Duration
+	cfg             *config.Config
+	flagToken       string
+	flagServer      string
+	flagVerbose     bool
+	flagPriority    string
+	flagLogLevel    string
+	flagTimeout     time.Duration
+	flagErrorFormat string
 )
 
 var rootCmd = &cobra.Command{
@@ -32,9 +34,17 @@ The following commands are currently supported:
 - tail: Provide a live 'tail' of a log`,
 	Version: app.Version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Apply error format before anything else so errors during init are formatted correctly
+		if flagErrorFormat == "json" {
+			errors.OutputJSON = true
+			cmd.Root().SilenceErrors = true
+			cmd.Root().SilenceUsage = true
+		}
+
 		// Skip authentication for commands that don't need API access
 		// Check both the command itself and its parent (for completion subcommands like "bash", "zsh", etc.)
 		if cmd.Name() == "completion" || cmd.Name() == "help" ||
+			cmd.Name() == "context" || cmd.Name() == "schema" ||
 			(cmd.Parent() != nil && cmd.Parent().Name() == "completion") {
 			return nil
 		}
@@ -62,6 +72,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagPriority, "priority", "high", "Query priority (high|low)")
 	rootCmd.PersistentFlags().StringVar(&flagLogLevel, "log-level", "info", "Log level (debug|info|warn|error)")
 	rootCmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", 30*time.Second, "Request timeout (e.g., 30s, 2m, 1h)")
+	rootCmd.PersistentFlags().StringVar(&flagErrorFormat, "error-format", "text", "Error output format: text|json")
 
 	rootCmd.AddCommand(queryCmd)
 	rootCmd.AddCommand(powerQueryCmd)
@@ -69,6 +80,8 @@ func init() {
 	rootCmd.AddCommand(facetQueryCmd)
 	rootCmd.AddCommand(timeseriesQueryCmd)
 	rootCmd.AddCommand(tailCmd)
+	rootCmd.AddCommand(contextCmd)
+	rootCmd.AddCommand(schemaCmd)
 }
 
 func Execute() error {

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/andreagrandi/logbasset/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+var schemaPretty bool
+
+var schemaCmd = &cobra.Command{
+	Use:   "schema [command]",
+	Short: "Print JSON schema for command inputs and outputs",
+	Long:  "Prints JSON schema describing a command's parameters, types, defaults, and valid values. With no arguments, lists all commands.",
+	Args:  cobra.MaximumNArgs(1),
+	Run:   runSchema,
+}
+
+func init() {
+	schemaCmd.Flags().BoolVar(&schemaPretty, "pretty", false, "Pretty-print JSON output")
+}
+
+type commandSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type paramSchema struct {
+	Name        string      `json:"name"`
+	Type        string      `json:"type"`
+	Required    bool        `json:"required"`
+	Default     interface{} `json:"default,omitempty"`
+	Enum        []string    `json:"enum,omitempty"`
+	Description string      `json:"description"`
+}
+
+type commandSchema struct {
+	Command    string        `json:"command"`
+	Args       []paramSchema `json:"args,omitempty"`
+	Flags      []paramSchema `json:"flags"`
+	OutputKeys []string      `json:"output_keys,omitempty"`
+}
+
+func runSchema(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		printSchemaJSON(getCommandList())
+		return
+	}
+
+	schema, ok := schemas[args[0]]
+	if !ok {
+		errors.HandleErrorAndExit(errors.NewUsageError(
+			fmt.Sprintf("unknown command: %s", args[0]),
+			fmt.Errorf("valid commands: query, power-query, numeric-query, facet-query, timeseries-query, tail"),
+		))
+	}
+
+	printSchemaJSON(schema)
+}
+
+func printSchemaJSON(data interface{}) {
+	var output []byte
+	var err error
+
+	if schemaPretty {
+		output, err = json.MarshalIndent(data, "", "  ")
+	} else {
+		output, err = json.Marshal(data)
+	}
+
+	if err != nil {
+		errors.HandleErrorAndExit(errors.NewParseError("failed to marshal schema JSON", err))
+	}
+
+	fmt.Println(string(output))
+}
+
+func getCommandList() []commandSummary {
+	return []commandSummary{
+		{Name: "query", Description: "Retrieve log data"},
+		{Name: "power-query", Description: "Execute PowerQuery"},
+		{Name: "numeric-query", Description: "Retrieve numeric/graph data"},
+		{Name: "facet-query", Description: "Retrieve common values for a field"},
+		{Name: "timeseries-query", Description: "Retrieve timeseries data"},
+		{Name: "tail", Description: "Provide a live tail of a log"},
+	}
+}
+
+var schemas = map[string]commandSchema{
+	"query": {
+		Command: "query",
+		Args: []paramSchema{
+			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
+		},
+		Flags: []paramSchema{
+			{Name: "start", Type: "string", Required: false, Description: "Start time (e.g., 1h, 24h, 7d, 2024-01-15)"},
+			{Name: "end", Type: "string", Required: false, Description: "End time (e.g., NOW, 1h, 2024-01-15 14:30)"},
+			{Name: "count", Type: "integer", Required: false, Default: 10, Description: "Number of log records (1-5000)"},
+			{Name: "mode", Type: "string", Required: false, Enum: []string{"head", "tail"}, Description: "Display mode"},
+			{Name: "columns", Type: "string", Required: false, Description: "Comma-separated list of columns"},
+			{Name: "output", Type: "string", Required: false, Default: "multiline", Enum: []string{"multiline", "singleline", "csv", "json", "json-pretty", "messageonly"}, Description: "Output format"},
+			{Name: "fields", Type: "string", Required: false, Description: "Comma-separated fields to include in JSON output (e.g., timestamp,message,severity)"},
+		},
+		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
+	},
+	"power-query": {
+		Command: "power-query",
+		Args: []paramSchema{
+			{Name: "query", Type: "string", Required: true, Description: "PowerQuery expression"},
+		},
+		Flags: []paramSchema{
+			{Name: "start", Type: "string", Required: true, Description: "Start time (required)"},
+			{Name: "end", Type: "string", Required: false, Description: "End time"},
+			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
+		},
+	},
+	"numeric-query": {
+		Command: "numeric-query",
+		Args: []paramSchema{
+			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
+		},
+		Flags: []paramSchema{
+			{Name: "function", Type: "string", Required: false, Description: "Function to compute (e.g., count, mean, min, max)"},
+			{Name: "start", Type: "string", Required: true, Description: "Start time (required)"},
+			{Name: "end", Type: "string", Required: false, Description: "End time"},
+			{Name: "buckets", Type: "integer", Required: false, Default: 1, Description: "Number of time buckets (1-5000)"},
+			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
+		},
+		OutputKeys: []string{"values"},
+	},
+	"facet-query": {
+		Command: "facet-query",
+		Args: []paramSchema{
+			{Name: "filter", Type: "string", Required: true, Description: "Log filter expression"},
+			{Name: "field", Type: "string", Required: true, Description: "Field name to facet on"},
+		},
+		Flags: []paramSchema{
+			{Name: "start", Type: "string", Required: true, Description: "Start time (required)"},
+			{Name: "end", Type: "string", Required: false, Description: "End time"},
+			{Name: "count", Type: "integer", Required: false, Default: 100, Description: "Number of distinct values (1-1000)"},
+			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
+		},
+		OutputKeys: []string{"value", "count"},
+	},
+	"timeseries-query": {
+		Command: "timeseries-query",
+		Args: []paramSchema{
+			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
+		},
+		Flags: []paramSchema{
+			{Name: "function", Type: "string", Required: false, Description: "Function to compute"},
+			{Name: "start", Type: "string", Required: true, Description: "Start time (required)"},
+			{Name: "end", Type: "string", Required: false, Description: "End time"},
+			{Name: "buckets", Type: "integer", Required: false, Default: 1, Description: "Number of time buckets (1-5000)"},
+			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
+			{Name: "only-use-summaries", Type: "boolean", Required: false, Default: false, Description: "Only query summaries"},
+			{Name: "no-create-summaries", Type: "boolean", Required: false, Default: false, Description: "Don't create summaries"},
+		},
+		OutputKeys: []string{"values"},
+	},
+	"tail": {
+		Command: "tail",
+		Args: []paramSchema{
+			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
+		},
+		Flags: []paramSchema{
+			{Name: "lines", Type: "integer", Required: false, Default: 10, Description: "Number of previous lines to show (-n)"},
+			{Name: "output", Type: "string", Required: false, Default: "messageonly", Enum: []string{"messageonly", "multiline", "singleline", "json"}, Description: "Output format"},
+		},
+		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
+	},
+}

--- a/internal/cli/tail.go
+++ b/internal/cli/tail.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -30,7 +31,7 @@ var (
 
 func init() {
 	tailCmd.Flags().IntVarP(&tailLines, "lines", "n", 10, "Output the previous K lines when starting the tail")
-	tailCmd.Flags().StringVar(&tailOutput, "output", "messageonly", "Output format: multiline|singleline|messageonly")
+	tailCmd.Flags().StringVar(&tailOutput, "output", "messageonly", "Output format: multiline|singleline|messageonly|json")
 }
 
 func runTail(cmd *cobra.Command, args []string) {
@@ -85,16 +86,31 @@ func runTail(cmd *cobra.Command, args []string) {
 		}
 	}()
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		tailOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	for event := range eventChan {
 		switch tailOutput {
 		case "multiline":
 			outputTailMultiLine(event)
 		case "singleline":
 			outputTailSingleLine(event)
+		case "json":
+			outputTailJSON(event)
 		default:
 			outputTailMessageOnly(event)
 		}
 	}
+}
+
+func outputTailJSON(event client.LogEvent) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	fmt.Println(string(data))
 }
 
 func outputTailMessageOnly(event client.LogEvent) {

--- a/internal/cli/timeseries_query.go
+++ b/internal/cli/timeseries_query.go
@@ -101,6 +101,11 @@ func runTimeseriesQuery(cmd *cobra.Command, args []string) {
 		errors.HandleErrorAndExit(err)
 	}
 
+	if !cmd.Flags().Changed("output") && !IsTTY() {
+		timeseriesQueryOutput = "json"
+		errors.OutputJSON = true
+	}
+
 	// Extract values from first result in the results array
 	var values []float64
 	if len(result.Results) > 0 {

--- a/internal/cli/tty.go
+++ b/internal/cli/tty.go
@@ -1,0 +1,12 @@
+package cli
+
+import "os"
+
+// IsTTY reports whether stdout is a terminal. It is a package-level variable for testability.
+var IsTTY = func() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,12 +88,25 @@ func validateConfig(config *Config) error {
 	}
 
 	if config.Server != "" {
-		if _, err := url.Parse(config.Server); err != nil {
+		parsedURL, err := url.Parse(config.Server)
+		if err != nil {
 			return errors.NewConfigError("invalid server URL", err)
 		}
 
 		if !strings.HasPrefix(config.Server, "http://") && !strings.HasPrefix(config.Server, "https://") {
 			return errors.NewConfigError("server URL must start with http:// or https://", nil)
+		}
+
+		if parsedURL.User != nil {
+			return errors.NewConfigError("server URL must not contain embedded credentials", nil)
+		}
+
+		if parsedURL.RawQuery != "" {
+			return errors.NewConfigError("server URL must not contain query parameters", nil)
+		}
+
+		if parsedURL.Fragment != "" {
+			return errors.NewConfigError("server URL must not contain a fragment", nil)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -168,6 +168,33 @@ func TestValidateConfig(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "server URL with embedded credentials",
+			config: &Config{
+				Token:    "test-token",
+				Server:   "https://user:pass@www.scalyr.com",
+				Priority: "high",
+			},
+			expectError: true,
+		},
+		{
+			name: "server URL with query params",
+			config: &Config{
+				Token:    "test-token",
+				Server:   "https://www.scalyr.com?foo=bar",
+				Priority: "high",
+			},
+			expectError: true,
+		},
+		{
+			name: "server URL with fragment",
+			config: &Config{
+				Token:    "test-token",
+				Server:   "https://www.scalyr.com#section",
+				Priority: "high",
+			},
+			expectError: true,
+		},
+		{
 			name: "invalid log level",
 			config: &Config{
 				Token:    "test-token",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -2,11 +2,15 @@ package errors
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/andreagrandi/logbasset/internal/logging"
 )
+
+// OutputJSON controls whether errors are emitted as JSON on stderr.
+var OutputJSON bool
 
 type ErrorType string
 
@@ -52,6 +56,31 @@ func (e *LogBassetError) Error() string {
 
 func (e *LogBassetError) Unwrap() error {
 	return e.Cause
+}
+
+type jsonErrorPayload struct {
+	Error jsonErrorDetail `json:"error"`
+}
+
+type jsonErrorDetail struct {
+	Type       string `json:"type"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
+	ExitCode   int    `json:"exit_code"`
+}
+
+// ToJSON returns the error as a JSON byte slice for machine consumption.
+func (e *LogBassetError) ToJSON() []byte {
+	payload := jsonErrorPayload{
+		Error: jsonErrorDetail{
+			Type:       string(e.Type),
+			Message:    e.Message,
+			Suggestion: e.Suggestion,
+			ExitCode:   e.GetExitCode(),
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return data
 }
 
 func (e *LogBassetError) GetExitCode() int {
@@ -166,13 +195,26 @@ func HandleErrorAndExit(err error) {
 	}
 
 	if logbassetErr, ok := err.(*LogBassetError); ok {
-		logging.WithFields(map[string]any{
-			"error_type": string(logbassetErr.Type),
-			"exit_code":  logbassetErr.GetExitCode(),
-		}).Error(logbassetErr.Error())
+		if OutputJSON {
+			fmt.Fprintln(os.Stderr, string(logbassetErr.ToJSON()))
+		} else {
+			logging.WithFields(map[string]any{
+				"error_type": string(logbassetErr.Type),
+				"exit_code":  logbassetErr.GetExitCode(),
+			}).Error(logbassetErr.Error())
+		}
 		os.Exit(logbassetErr.GetExitCode())
 	}
 
-	logging.Error(err.Error())
+	if OutputJSON {
+		genericErr := &LogBassetError{
+			Type:     APIError,
+			Message:  err.Error(),
+			ExitCode: ExitGeneral,
+		}
+		fmt.Fprintln(os.Stderr, string(genericErr.ToJSON()))
+	} else {
+		logging.Error(err.Error())
+	}
 	os.Exit(ExitGeneral)
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -155,12 +155,12 @@ func TestLogBassetError_NilCause(t *testing.T) {
 
 func TestLogBassetError_ToJSON(t *testing.T) {
 	tests := []struct {
-		name         string
-		err          *LogBassetError
-		expectType   string
-		expectMsg    string
-		expectSugg   string
-		expectCode   int
+		name       string
+		err        *LogBassetError
+		expectType string
+		expectMsg  string
+		expectSugg string
+		expectCode int
 	}{
 		{
 			name:       "auth error",

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -2,10 +2,12 @@ package errors
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogBassetError_Error(t *testing.T) {
@@ -149,6 +151,68 @@ func TestLogBassetError_Unwrap(t *testing.T) {
 func TestLogBassetError_NilCause(t *testing.T) {
 	err := NewAuthError("test", nil)
 	assert.Nil(t, err.Unwrap())
+}
+
+func TestLogBassetError_ToJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          *LogBassetError
+		expectType   string
+		expectMsg    string
+		expectSugg   string
+		expectCode   int
+	}{
+		{
+			name:       "auth error",
+			err:        NewAuthError("API token is required", nil),
+			expectType: "AUTH_ERROR",
+			expectMsg:  "API token is required",
+			expectCode: ExitAuth,
+		},
+		{
+			name:       "validation error",
+			err:        NewValidationError("invalid count", fmt.Errorf("too high")),
+			expectType: "VALIDATION_ERROR",
+			expectMsg:  "invalid count",
+			expectCode: ExitValidation,
+		},
+		{
+			name:       "network error",
+			err:        NewNetworkError("connection refused", nil),
+			expectType: "NETWORK_ERROR",
+			expectMsg:  "connection refused",
+			expectCode: ExitNetwork,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := tt.err.ToJSON()
+
+			var payload struct {
+				Error struct {
+					Type       string `json:"type"`
+					Message    string `json:"message"`
+					Suggestion string `json:"suggestion"`
+					ExitCode   int    `json:"exit_code"`
+				} `json:"error"`
+			}
+
+			err := json.Unmarshal(data, &payload)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectType, payload.Error.Type)
+			assert.Equal(t, tt.expectMsg, payload.Error.Message)
+			assert.Equal(t, tt.expectCode, payload.Error.ExitCode)
+			assert.NotEmpty(t, payload.Error.Suggestion)
+		})
+	}
+}
+
+func TestToJSON_ValidJSON(t *testing.T) {
+	err := NewAPIError("something failed", fmt.Errorf("cause"))
+	data := err.ToJSON()
+
+	assert.True(t, json.Valid(data), "ToJSON should produce valid JSON")
 }
 
 func TestNewContextError(t *testing.T) {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -190,6 +190,7 @@ func ValidateMode(mode string, validModes []string) error {
 		fmt.Errorf("valid modes: %s", strings.Join(validModes, ", ")),
 	)
 }
+
 // ValidateNoControlChars rejects ASCII control characters (0x00-0x1F except tab/newline/CR, and 0x7F).
 func ValidateNoControlChars(input string, fieldName string) error {
 	for i, r := range input {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -190,6 +190,22 @@ func ValidateMode(mode string, validModes []string) error {
 		fmt.Errorf("valid modes: %s", strings.Join(validModes, ", ")),
 	)
 }
+// ValidateNoControlChars rejects ASCII control characters (0x00-0x1F except tab/newline/CR, and 0x7F).
+func ValidateNoControlChars(input string, fieldName string) error {
+	for i, r := range input {
+		if r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		if (r >= 0x00 && r <= 0x1F) || r == 0x7F {
+			return errors.NewValidationError(
+				fmt.Sprintf("%s contains invalid control character at position %d", fieldName, i),
+				fmt.Errorf("control characters (except tab, newline, CR) are not allowed"),
+			)
+		}
+	}
+	return nil
+}
+
 func ValidateColumns(columns string) error {
 	if columns == "" {
 		return nil
@@ -209,6 +225,48 @@ func ValidateColumns(columns string) error {
 			return errors.NewValidationError(
 				"column names cannot be empty",
 				nil,
+			)
+		}
+
+		if err := ValidateNoControlChars(col, "column name"); err != nil {
+			return err
+		}
+
+		if strings.Contains(col, "../") || strings.Contains(col, "..\\") || strings.HasPrefix(col, "/") || strings.HasPrefix(col, "\\") {
+			return errors.NewValidationError(
+				fmt.Sprintf("column name contains invalid path characters: %s", col),
+				fmt.Errorf("column names must not contain path traversal sequences"),
+			)
+		}
+	}
+
+	return nil
+}
+
+// ValidateFields validates the --fields flag value.
+func ValidateFields(fields string) error {
+	if fields == "" {
+		return nil
+	}
+
+	fieldList := strings.Split(fields, ",")
+	for _, f := range fieldList {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			return errors.NewValidationError(
+				"field names cannot be empty",
+				nil,
+			)
+		}
+
+		if err := ValidateNoControlChars(f, "field name"); err != nil {
+			return err
+		}
+
+		if strings.Contains(f, "../") || strings.Contains(f, "..\\") || strings.HasPrefix(f, "/") || strings.HasPrefix(f, "\\") {
+			return errors.NewValidationError(
+				fmt.Sprintf("field name contains invalid path characters: %s", f),
+				fmt.Errorf("field names must not contain path traversal sequences"),
 			)
 		}
 	}
@@ -292,6 +350,10 @@ func ValidateQueryParams(params QueryValidationParams, config *ValidationConfig)
 	}
 
 	if err := ValidatePriority(params.Priority, config.ValidPriorities); err != nil {
+		return err
+	}
+
+	if err := ValidateNoControlChars(params.Query, "filter"); err != nil {
 		return err
 	}
 

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -179,6 +179,37 @@ func TestValidateMode(t *testing.T) {
 	}
 }
 
+func TestValidateNoControlChars(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{"empty string", "", false},
+		{"normal text", "hello world", false},
+		{"tab allowed", "hello\tworld", false},
+		{"newline allowed", "hello\nworld", false},
+		{"CR allowed", "hello\rworld", false},
+		{"null byte", "hello\x00world", true},
+		{"bell char", "hello\x07world", true},
+		{"escape char", "hello\x1bworld", true},
+		{"DEL char", "hello\x7fworld", true},
+		{"form feed", "hello\x0cworld", true},
+		{"backspace", "hello\x08world", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNoControlChars(tt.input, "test")
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateColumns(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -191,11 +222,43 @@ func TestValidateColumns(t *testing.T) {
 		{"columns with spaces", "timestamp, severity, message", false},
 		{"empty column in list", "timestamp,,message", true},
 		{"only spaces in column", "timestamp,   ,message", true},
+		{"path traversal in column", "../../etc/passwd", true},
+		{"backslash traversal", "..\\windows\\system32", true},
+		{"absolute path column", "/etc/passwd", true},
+		{"control char in column", "time\x00stamp", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateColumns(tt.columns)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		fields    string
+		wantError bool
+	}{
+		{"empty fields", "", false},
+		{"single field", "timestamp", false},
+		{"multiple fields", "timestamp,message,severity", false},
+		{"fields with spaces", "timestamp, message, severity", false},
+		{"empty field in list", "timestamp,,message", true},
+		{"path traversal", "../../etc/passwd", true},
+		{"absolute path", "/etc/passwd", true},
+		{"control char", "time\x00stamp", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFields(tt.fields)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
## Summary

- **`logbasset context`** — embedded agent reference document (~120 lines) with authentication, commands, flags, time formats, exit codes, examples
- **`logbasset schema [command]`** — JSON schema for command parameters with types, defaults, enums; no args lists all commands
- **`--error-format json`** global flag — structured JSON errors on stderr: `{"error":{"type":"AUTH_ERROR","message":"...","suggestion":"...","exit_code":4}}`
- **TTY auto-detection** — output defaults to `json` when stdout is piped (non-TTY); overridable with explicit `--output`
- **Input hardening** — rejects control characters in filters/columns/fields, path traversal in names, embedded credentials/query params/fragments in server URLs
- **`--fields` flag on query** — select specific fields in JSON output to reduce context window usage (e.g., `--fields timestamp,message,severity`)
- **`json` output for tail** — NDJSON (one JSON object per line)

## Test plan

- [x] `make test` — all tests pass
- [x] `make build` — binary builds
- [ ] `logbasset context | head` — prints agent reference
- [ ] `logbasset schema query | jq .` — valid JSON schema
- [ ] `logbasset query --error-format json` with no token — JSON error on stderr
- [ ] `logbasset query '"test"' --start 1h | head -1` — JSON output when piped
- [ ] `logbasset query '"test"' --start 1h --output json --fields timestamp,message` — filtered fields