### PR TITLE
ci: add Go 1.24 and 1.25 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        go-version: ['1.26.1']
+        go-version: ['1.24', '1.25', '1.26.1']
     
     steps:
     - name: Checkout code
@@ -57,10 +57,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        go-version: ['1.26.1']
+        go-version: ['1.24', '1.25', '1.26.1']
     
     steps:
     - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/andreagrandi/logbasset
 
-go 1.26.1
+go 1.24
+
+toolchain go1.26.1
 
 require (
 	github.com/sirupsen/logrus v1.9.4


### PR DESCRIPTION
## Summary
- Expand CI test and build matrices to include Go 1.24 and 1.25 alongside 1.26.1
- Ensures backward compatibility with the two previous Go minor versions

## Test plan
- [ ] CI passes for all three Go versions in the matrix