### PR TITLE
security: redact Scalyr API token in verbose request payload logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Security
+- Redact Scalyr API token in verbose/debug log output of request payloads (#37)
+
 ## v0.4.8 - 2026-03-05
 
 ### Changed

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,7 +18,29 @@ import (
 const (
 	DefaultServer = "https://www.scalyr.com"
 	APIVersion    = "v1"
+	redactedValue = "***REDACTED***"
 )
+
+var sensitiveParamKeys = []string{"token", "Token", "TOKEN"}
+
+// redactSensitiveParams returns a shallow copy of params with sensitive values
+// (such as the Scalyr API token) replaced by a placeholder. The original map is
+// left untouched so the real request payload is unaffected.
+func redactSensitiveParams(params map[string]interface{}) map[string]interface{} {
+	if params == nil {
+		return nil
+	}
+	redacted := make(map[string]interface{}, len(params))
+	for k, v := range params {
+		redacted[k] = v
+	}
+	for _, key := range sensitiveParamKeys {
+		if _, ok := redacted[key]; ok {
+			redacted[key] = redactedValue
+		}
+	}
+	return redacted
+}
 
 type Client struct {
 	server     string
@@ -77,7 +99,12 @@ func (c *Client) makeRequest(ctx context.Context, endpoint string, params map[st
 			"url":      url,
 			"endpoint": endpoint,
 		}).Debug("Making HTTP request")
-		logging.WithField("request_data", string(jsonData)).Debug("Request payload")
+		redactedJSON, err := json.Marshal(redactSensitiveParams(params))
+		if err != nil {
+			logging.WithField("error", err).Debug("Failed to marshal redacted request payload for logging")
+		} else {
+			logging.WithField("request_data", string(redactedJSON)).Debug("Request payload")
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andreagrandi/logbasset/internal/logging"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -556,6 +558,138 @@ func TestMockHTTPClient_DefaultBehavior(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestRedactSensitiveParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "nil map",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "redacts token field",
+			input: map[string]interface{}{
+				"token":  "super-secret",
+				"filter": "error",
+			},
+			expected: map[string]interface{}{
+				"token":  "***REDACTED***",
+				"filter": "error",
+			},
+		},
+		{
+			name: "no token field is unchanged",
+			input: map[string]interface{}{
+				"filter":    "error",
+				"queryType": "log",
+			},
+			expected: map[string]interface{}{
+				"filter":    "error",
+				"queryType": "log",
+			},
+		},
+		{
+			name: "preserves continuationToken (not a credential field)",
+			input: map[string]interface{}{
+				"token":             "secret",
+				"continuationToken": "cursor-abc",
+			},
+			expected: map[string]interface{}{
+				"token":             "***REDACTED***",
+				"continuationToken": "cursor-abc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := redactSensitiveParams(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRedactSensitiveParams_DoesNotMutateInput(t *testing.T) {
+	original := map[string]interface{}{
+		"token":  "super-secret",
+		"filter": "error",
+	}
+	_ = redactSensitiveParams(original)
+	assert.Equal(t, "super-secret", original["token"], "original params map must not be mutated")
+}
+
+func TestClient_makeRequest_VerboseLogsRedactToken(t *testing.T) {
+	// Capture log output and force debug level
+	originalLevel := logging.GetLogger().GetLevel()
+	originalOutput := logging.GetLogger().Out
+	defer func() {
+		logging.GetLogger().SetLevel(originalLevel)
+		logging.SetOutput(originalOutput)
+	}()
+
+	var logBuf bytes.Buffer
+	logging.SetOutput(&logBuf)
+	logging.GetLogger().SetLevel(logrus.DebugLevel)
+
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			// Confirm the actual request body still contains the real token —
+			// redaction is for logs only, not for the request itself.
+			body, _ := io.ReadAll(req.Body)
+			var reqData map[string]interface{}
+			require.NoError(t, json.Unmarshal(body, &reqData))
+			assert.Equal(t, "super-secret-token", reqData["token"])
+
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("super-secret-token", "https://test.com", true, mockClient)
+	ctx := context.Background()
+
+	_, err := client.makeRequest(ctx, "query", map[string]interface{}{"filter": "error"})
+	require.NoError(t, err)
+
+	logOutput := logBuf.String()
+	assert.NotContains(t, logOutput, "super-secret-token", "log output must not contain the raw API token")
+	assert.Contains(t, logOutput, "***REDACTED***", "log output should contain the redaction placeholder")
+	// Useful debug context should still be present.
+	assert.Contains(t, logOutput, "filter")
+	assert.Contains(t, logOutput, "https://test.com/api/query")
+	assert.Contains(t, logOutput, "endpoint")
+}
+
+func TestClient_makeRequest_OriginalParamsNotMutated(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("super-secret-token", "https://test.com", true, mockClient)
+	params := map[string]interface{}{"filter": "error"}
+	_, err := client.makeRequest(context.Background(), "query", params)
+	require.NoError(t, err)
+
+	// makeRequest sets params["token"] for the real request body; ensure it
+	// holds the actual token, not the redacted placeholder.
+	assert.Equal(t, "super-secret-token", params["token"])
 }
 
 func TestClient_makeRequest_ContextCancellation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Verbose/debug logging marshaled the full request params map, which included the Scalyr API token, leaking credentials into log output.
- `makeRequest` now logs a redacted copy of the payload (`token` -> `***REDACTED***`) while still sending the real token in the actual HTTP request body.
- All query types funnel through `makeRequest`, so redaction applies consistently to `query`, `power-query`, `numeric-query`, `facet-query`, `timeseries-query`, and `tail`.
- Endpoint and URL debug context are preserved.

## Acceptance criteria (from #37)
- [x] Raw API tokens never appear in verbose/debug logs.
- [x] Tests cover request-payload redaction.
- [x] Existing command output behavior remains unchanged (real request body is unaffected).

## Test plan
- [x] `go test ./...` — all packages pass.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l .` — no formatting issues.
- [x] New tests: `TestRedactSensitiveParams`, `TestRedactSensitiveParams_DoesNotMutateInput`, `TestClient_makeRequest_VerboseLogsRedactToken`, `TestClient_makeRequest_OriginalParamsNotMutated`.

Closes #37