### PR TITLE
docs: add session start workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # AGENTS.md - LogBasset Development Guide
 
+## Session Start Workflow
+
+Before making code or documentation changes in this repo:
+
+1. Switch back to `master`.
+2. Pull the latest changes with `git pull --ff-only`.
+3. Create a new branch with a short, descriptive name related to the feature being added or the bug being fixed.
+4. Make the requested changes on that branch.
+
+Do not start work from an old feature branch unless the user explicitly asks to continue that branch.
+
 ## Project Structure
 LogBasset follows the standard Go project layout:
 ```


### PR DESCRIPTION
Summary: Documents the required session start workflow before making code or documentation changes: switch to master, pull latest changes, create a descriptive branch, then work there. Testing: Not run; documentation-only change.