### PR TITLE
feat: add bounded retry with backoff and rate-limit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Bounded retry with exponential backoff and jitter for transient network failures and 5xx responses; honor `Retry-After` on 429 throttling (#39)
+
 ### Changed
 - Consolidated cross-file CLI output helpers and removed unused `internal/output` package (#38)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,10 +44,11 @@ func redactSensitiveParams(params map[string]interface{}) map[string]interface{}
 }
 
 type Client struct {
-	server     string
-	token      string
-	httpClient HTTPClient
-	verbose    bool
+	server      string
+	token       string
+	httpClient  HTTPClient
+	verbose     bool
+	retryPolicy RetryPolicy
 }
 
 func New(token, server string, verbose bool) *Client {
@@ -66,15 +68,32 @@ func NewWithHTTPClient(token, server string, verbose bool, httpClient HTTPClient
 	}
 
 	return &Client{
-		server:     strings.TrimSuffix(server, "/"),
-		token:      token,
-		httpClient: httpClient,
-		verbose:    verbose,
+		server:      strings.TrimSuffix(server, "/"),
+		token:       token,
+		httpClient:  httpClient,
+		verbose:     verbose,
+		retryPolicy: defaultRetryPolicy(),
 	}
 }
 
 func (c *Client) SetToken(token string) {
 	c.token = token
+}
+
+// SetRetryPolicy overrides the default retry policy. Setting MaxRetries to 0
+// disables retries entirely.
+func (c *Client) SetRetryPolicy(policy RetryPolicy) {
+	c.retryPolicy = policy
+}
+
+// drainAndClose discards any remaining bytes in the response body so the
+// underlying TCP connection can be reused, then closes it.
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
 }
 
 func (c *Client) makeRequest(ctx context.Context, endpoint string, params map[string]interface{}) (*http.Response, error) {
@@ -93,10 +112,10 @@ func (c *Client) makeRequest(ctx context.Context, endpoint string, params map[st
 		return nil, errors.NewParseError("failed to marshal request data", err)
 	}
 
-	url := fmt.Sprintf("%s/api/%s", c.server, endpoint)
+	requestURL := fmt.Sprintf("%s/api/%s", c.server, endpoint)
 	if c.verbose {
 		logging.WithFields(map[string]any{
-			"url":      url,
+			"url":      requestURL,
 			"endpoint": endpoint,
 		}).Debug("Making HTTP request")
 		redactedJSON, err := json.Marshal(redactSensitiveParams(params))
@@ -107,21 +126,90 @@ func (c *Client) makeRequest(ctx context.Context, endpoint string, params map[st
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, errors.NewNetworkError("failed to create request", err)
+	policy := c.retryPolicy
+	if policy.MaxRetries < 0 {
+		policy.MaxRetries = 0
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	var (
+		resp        *http.Response
+		execErr     error
+		lastStatus  int
+		lastBodyStr string
+	)
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		// Check if the error is context-related
-		if ctx.Err() != nil {
-			return nil, errors.NewContextError("request was cancelled or timed out", ctx.Err())
+	for attempt := 0; attempt <= policy.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := policy.backoffDelay(attempt - 1)
+			if resp != nil {
+				if ra := parseRetryAfter(resp.Header.Get("Retry-After")); ra > 0 {
+					delay = ra
+					if delay > policy.MaxDelay {
+						delay = policy.MaxDelay
+					}
+				}
+				drainAndClose(resp.Body)
+				resp = nil
+			}
+			if c.verbose {
+				logging.WithFields(map[string]any{
+					"attempt":     attempt,
+					"delay":       delay.String(),
+					"max_retries": policy.MaxRetries,
+				}).Debug("Retrying request after transient failure")
+			}
+			if err := sleepWithContext(ctx, delay); err != nil {
+				return nil, errors.NewContextError("request was cancelled or timed out", err)
+			}
 		}
-		return nil, errors.NewNetworkError("failed to execute request", err)
+
+		req, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewReader(jsonData))
+		if err != nil {
+			return nil, errors.NewNetworkError("failed to create request", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, execErr = c.httpClient.Do(req)
+		if execErr != nil {
+			if ctx.Err() != nil {
+				return nil, errors.NewContextError("request was cancelled or timed out", ctx.Err())
+			}
+			if attempt < policy.MaxRetries {
+				if c.verbose {
+					logging.WithFields(map[string]any{
+						"attempt": attempt + 1,
+						"error":   execErr.Error(),
+					}).Debug("Transient network error, will retry")
+				}
+				continue
+			}
+			return nil, errors.NewNetworkError("failed to execute request", execErr)
+		}
+
+		if !isRetryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+
+		lastStatus = resp.StatusCode
+		if c.verbose {
+			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			lastBodyStr = string(snippet)
+			logging.WithFields(map[string]any{
+				"status":  resp.StatusCode,
+				"attempt": attempt + 1,
+				"body":    lastBodyStr,
+			}).Debug("Retryable HTTP status received")
+		}
+
+		if attempt >= policy.MaxRetries {
+			drainAndClose(resp.Body)
+			msg := fmt.Sprintf("server returned status %d after %d attempts", lastStatus, attempt+1)
+			if lastBodyStr != "" {
+				msg = fmt.Sprintf("%s: %s", msg, lastBodyStr)
+			}
+			return nil, errors.NewNetworkError(msg, nil)
+		}
 	}
 
-	return resp, nil
+	return resp, execErr
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -132,6 +132,7 @@ func TestClient_makeRequest_NetworkError(t *testing.T) {
 	}
 
 	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(RetryPolicy{MaxRetries: 0})
 	ctx := context.Background()
 
 	_, err := client.makeRequest(ctx, "query", map[string]interface{}{})

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"context"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultMaxRetries = 3
+	defaultBaseDelay  = 200 * time.Millisecond
+	defaultMaxDelay   = 10 * time.Second
+)
+
+// RetryPolicy controls how transient failures are retried.
+type RetryPolicy struct {
+	MaxRetries int
+	BaseDelay  time.Duration
+	MaxDelay   time.Duration
+}
+
+func defaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxRetries: defaultMaxRetries,
+		BaseDelay:  defaultBaseDelay,
+		MaxDelay:   defaultMaxDelay,
+	}
+}
+
+// isRetryableStatus returns true for HTTP status codes that indicate a
+// transient failure worth retrying (5xx server errors and 429 throttling).
+func isRetryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || (code >= 500 && code <= 599)
+}
+
+// parseRetryAfter parses the Retry-After header value, which may be either a
+// delta in seconds or an HTTP-date. Returns 0 when absent or unparseable.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// backoffDelay computes the delay before the next retry attempt using
+// exponential backoff with full jitter, bounded by MaxDelay.
+func (p RetryPolicy) backoffDelay(attempt int) time.Duration {
+	if p.BaseDelay <= 0 {
+		return 0
+	}
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt > 30 {
+		attempt = 30
+	}
+	delay := p.BaseDelay << attempt
+	if delay <= 0 || delay > p.MaxDelay {
+		delay = p.MaxDelay
+	}
+	return time.Duration(rand.Int63n(int64(delay) + 1))
+}
+
+// sleepWithContext sleeps for d or returns early when the context is done.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -1,0 +1,383 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fastRetryPolicy(maxRetries int) RetryPolicy {
+	return RetryPolicy{
+		MaxRetries: maxRetries,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   10 * time.Millisecond,
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, isRetryableStatus(tt.code), "status %d", tt.code)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
+	assert.Equal(t, 5*time.Second, parseRetryAfter("5"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("not-a-number"))
+
+	future := time.Now().Add(3 * time.Second).UTC().Format(http.TimeFormat)
+	d := parseRetryAfter(future)
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, 4*time.Second)
+
+	past := time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat)
+	assert.Equal(t, time.Duration(0), parseRetryAfter(past))
+}
+
+func TestBackoffDelay_BoundedByMaxDelay(t *testing.T) {
+	policy := RetryPolicy{BaseDelay: 100 * time.Millisecond, MaxDelay: 500 * time.Millisecond}
+	for attempt := 0; attempt < 10; attempt++ {
+		d := policy.backoffDelay(attempt)
+		assert.LessOrEqual(t, d, policy.MaxDelay)
+		assert.GreaterOrEqual(t, d, time.Duration(0))
+	}
+}
+
+func TestBackoffDelay_ZeroBaseDelay(t *testing.T) {
+	policy := RetryPolicy{BaseDelay: 0, MaxDelay: 500 * time.Millisecond}
+	assert.Equal(t, time.Duration(0), policy.backoffDelay(0))
+	assert.Equal(t, time.Duration(0), policy.backoffDelay(5))
+}
+
+func TestSleepWithContext_CompletesNormally(t *testing.T) {
+	ctx := context.Background()
+	start := time.Now()
+	err := sleepWithContext(ctx, 5*time.Millisecond)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 5*time.Millisecond)
+}
+
+func TestSleepWithContext_CancelledEarly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := sleepWithContext(ctx, 10*time.Second)
+	assert.Equal(t, context.Canceled, err)
+}
+
+func TestSleepWithContext_ZeroDuration(t *testing.T) {
+	err := sleepWithContext(context.Background(), 0)
+	assert.NoError(t, err)
+}
+
+func TestClient_makeRequest_RetriesTransientServerError(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n < 3 {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("server boom")),
+					Header:     http.Header{},
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(3))
+
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_RetriesTransientNetworkError(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n < 2 {
+				return nil, errors.New("connection reset")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(3))
+
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_FailsAfterMaxRetries_ServerError(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader("bad gateway")),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(2))
+
+	_, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+	assert.Contains(t, err.Error(), "after 3 attempts")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_FailsAfterMaxRetries_NetworkError(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, errors.New("dial tcp: connection refused")
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(2))
+
+	_, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute request")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_DoesNotRetry4xx(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"error","message":"invalid token"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(5))
+
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_DoesNotRetry_BadRequest(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"error","message":"bad query"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(5))
+
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_RespectsRetryAfter429(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n == 1 {
+				header := http.Header{}
+				header.Set("Retry-After", "1")
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader("throttled")),
+					Header:     header,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(RetryPolicy{
+		MaxRetries: 2,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   5 * time.Second,
+	})
+
+	start := time.Now()
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+	assert.GreaterOrEqual(t, elapsed, 900*time.Millisecond, "should have waited per Retry-After")
+}
+
+func TestClient_makeRequest_RetryAfterCappedByMaxDelay(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			n := atomic.AddInt32(&attempts, 1)
+			if n == 1 {
+				header := http.Header{}
+				header.Set("Retry-After", "3600")
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader("throttled")),
+					Header:     header,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"success"}`)),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(RetryPolicy{
+		MaxRetries: 1,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   50 * time.Millisecond,
+	})
+
+	start := time.Now()
+	resp, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Less(t, elapsed, 1*time.Second, "Retry-After should be capped by MaxDelay")
+}
+
+func TestClient_makeRequest_ContextCancelledDuringBackoff(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("boom")),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(RetryPolicy{
+		MaxRetries: 5,
+		BaseDelay:  500 * time.Millisecond,
+		MaxDelay:   1 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.makeRequest(ctx, "query", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+	assert.Less(t, int32(atomic.LoadInt32(&attempts)), int32(6), "should stop retrying once context is cancelled")
+}
+
+func TestClient_makeRequest_NoRetriesWhenDisabled(t *testing.T) {
+	var attempts int32
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("boom")),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+
+	client := NewWithHTTPClient("token", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(RetryPolicy{MaxRetries: 0})
+
+	_, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestClient_makeRequest_AuthErrorNotRetried(t *testing.T) {
+	t.Setenv("scalyr_readlog_token", "")
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			t.Fatal("HTTP client should not be called when token is missing")
+			return nil, nil
+		},
+	}
+	client := NewWithHTTPClient("", "https://test.com", false, mockClient)
+	client.SetRetryPolicy(fastRetryPolicy(5))
+
+	_, err := client.makeRequest(context.Background(), "query", map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API token is required")
+}


### PR DESCRIPTION
## Summary
- Retry transient network failures and 5xx responses in `client.makeRequest` with exponential backoff and full jitter (3 retries / 200ms base / 10s cap by default).
- Honor `Retry-After` on 429 throttling, capped by `MaxDelay`.
- Non-retryable responses (2xx, 4xx) and auth/validation errors still pass through or fail immediately.
- Each retry attempt is logged at debug level when `--verbose` is enabled.
- Retry policy is overridable via `Client.SetRetryPolicy` for testing or callers that need different bounds.

Closes #39

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `make build` succeeds
- [x] New tests cover: transient 5xx → success, transient network error → success, persistent 5xx fails after max retries, persistent network error fails after max retries, 401/400 not retried, `Retry-After` respected (with `MaxDelay` cap), context cancellation during backoff, retries disabled, missing-token short-circuits before any HTTP call