### PR TITLE
feat: add compact output mode and pager integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,20 @@ Before making code or documentation changes in this repo:
 
 Do not start work from an old feature branch unless the user explicitly asks to continue that branch.
 
+## When Adding User-Facing Features
+
+Any change that adds, renames, or removes a flag, command, output format, or
+exit code must update every place users (and agents) discover it. Skipping any
+of these leaves the docs lying:
+
+- `README.md` — user-facing examples and option lists.
+- `CHANGELOG.md` — entry under `[Unreleased]` referencing the issue/PR.
+- `CONTEXT.md` **and** `internal/cli/context_embed.md` — both must stay
+  byte-identical; the embed file is compiled into the `context` command.
+- `internal/cli/schema.go` — enum/default/description entries for the
+  affected command so `logbasset schema` reports the new state.
+- Help strings on the relevant `cobra.Command` flag definitions.
+
 ## Project Structure
 LogBasset follows the standard Go project layout:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- `compact` output format for `query` and `tail` showing one event per line as `HH:MM:SS <severity> <message>` for scanning large result sets (#40)
+- `--pager` global flag that pipes output through `$PAGER` (defaults to `less -RF`) when stdout is a terminal (#40)
 - Bounded retry with exponential backoff and jitter for transient network failures and 5xx responses; honor `Retry-After` on 429 throttling (#39)
 
 ### Changed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,7 @@ Server URL (default `https://www.scalyr.com`):
 | `--log-level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
 | `--error-format` | string | `text` | Error output format: `text` or `json` |
+| `--pager` | bool | false | Pipe output through `$PAGER` (default `less -RF`) when stdout is a terminal |
 
 ## Flags That Do NOT Exist
 
@@ -61,13 +62,15 @@ When using `--start` without `--end`, the API returns only 24h from start. Use `
 ## Output Formats
 
 ### query command
-`--output`: `multiline` (default in TTY), `singleline`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+`--output`: `multiline` (default in TTY), `singleline`, `compact`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+
+`compact` prints one event per line as `HH:MM:SS <severity-char> <message>` where the severity char is `D` (≤2), `I` (3), `W` (4), `E` (5), or `F` (≥6). Designed for scanning large result sets.
 
 ### power-query, numeric-query, facet-query, timeseries-query
 `--output`: `csv` (default in TTY), `json` (default in pipe), `json-pretty`
 
 ### tail command
-`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `json` (default in pipe)
+`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `compact`, `json` (default in pipe)
 
 Use `--fields` with `query --output json` to select specific fields and reduce output size.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ logbasset query '$source="accessLog"' --output=csv --columns='status,uriPath' --
 - `--count=nnn`: Number of log records to retrieve (1-5000), defaults to 10
 - `--mode=head|tail`: Whether to display from start or end of time range
 - `--columns="..."`: Which log attributes to display (comma-separated)
-- `--output=multiline|singleline|csv|json|json-pretty`: Output format
+- `--output=multiline|singleline|compact|csv|json|json-pretty`: Output format
 - `--priority=high|low`: Query execution priority
 
 ### Power Query
@@ -242,7 +242,7 @@ logbasset tail --output multiline
 
 **Options:**
 - `--lines=K` or `-n K`: Output the previous K lines when starting (defaults to 10)
-- `--output=multiline|singleline|messageonly`: Output format (defaults to messageonly)
+- `--output=multiline|singleline|compact|messageonly`: Output format (defaults to messageonly)
 - `--priority=high|low`: Query execution priority
 
 ## Global Options
@@ -254,6 +254,7 @@ These options are available for all commands:
 - `--verbose`: Enable verbose output for debugging
 - `--priority=high|low`: Query execution priority (defaults to high)
 - `--log-level=debug|info|warn|error`: Set logging level (defaults to info)
+- `--pager`: Pipe output through `$PAGER` (defaults to `less -RF`) when stdout is a terminal
 
 ## Output Formats
 
@@ -269,7 +270,24 @@ These options are available for all commands:
 ### Text Output
 - `multiline`: Verbose format with each attribute on separate lines
 - `singleline`: Compact format with all attributes on one line
+- `compact`: One line per event, `HH:MM:SS <severity> <message>` — designed for scanning large result sets
 - `messageonly`: Only the log message (useful for tail)
+
+In `compact` mode the severity column is a single letter: `D` (debug, severity ≤ 2), `I` (info, 3), `W` (warning, 4), `E` (error, 5), `F` (fatal, ≥ 6).
+
+### Paging Large Output
+
+Two ways to make large query results easier to scan:
+
+```bash
+# Built-in: pipe through $PAGER (defaults to less -RF) while keeping stderr on the terminal
+logbasset query 'error' --count=5000 --output=compact --pager
+
+# Manual: just pipe to your pager of choice
+logbasset query 'error' --count=5000 --output=compact | less -R
+```
+
+`--pager` only activates when stdout is a terminal, so scripts and pipelines (including JSON/CSV output redirected to a file) are unaffected.
 
 ## Usage Limits
 

--- a/internal/cli/context_embed.md
+++ b/internal/cli/context_embed.md
@@ -38,6 +38,7 @@ Server URL (default `https://www.scalyr.com`):
 | `--log-level` | string | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
 | `--error-format` | string | `text` | Error output format: `text` or `json` |
+| `--pager` | bool | false | Pipe output through `$PAGER` (default `less -RF`) when stdout is a terminal |
 
 ## Flags That Do NOT Exist
 
@@ -61,13 +62,15 @@ When using `--start` without `--end`, the API returns only 24h from start. Use `
 ## Output Formats
 
 ### query command
-`--output`: `multiline` (default in TTY), `singleline`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+`--output`: `multiline` (default in TTY), `singleline`, `compact`, `csv`, `json` (default in pipe), `json-pretty`, `messageonly`
+
+`compact` prints one event per line as `HH:MM:SS <severity-char> <message>` where the severity char is `D` (≤2), `I` (3), `W` (4), `E` (5), or `F` (≥6). Designed for scanning large result sets.
 
 ### power-query, numeric-query, facet-query, timeseries-query
 `--output`: `csv` (default in TTY), `json` (default in pipe), `json-pretty`
 
 ### tail command
-`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `json` (default in pipe)
+`--output`: `messageonly` (default in TTY), `multiline`, `singleline`, `compact`, `json` (default in pipe)
 
 Use `--fields` with `query --output json` to select specific fields and reduce output size.
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -6,9 +6,41 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/andreagrandi/logbasset/internal/errors"
 )
+
+// formatCompactTimestamp converts a Scalyr nanosecond timestamp string into HH:MM:SS.
+// Falls back to the original value if parsing fails.
+func formatCompactTimestamp(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	if nanos, err := strconv.ParseInt(ts, 10, 64); err == nil {
+		return time.Unix(0, nanos).UTC().Format("15:04:05")
+	}
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t.UTC().Format("15:04:05")
+	}
+	return ts
+}
+
+// severityChar maps a Scalyr severity level to a single character for compact output.
+func severityChar(sev int) string {
+	switch {
+	case sev <= 2:
+		return "D"
+	case sev == 3:
+		return "I"
+	case sev == 4:
+		return "W"
+	case sev == 5:
+		return "E"
+	default:
+		return "F"
+	}
+}
 
 func outputJSON(data any, pretty bool) {
 	var output []byte

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -70,3 +70,41 @@ func TestOutputNumericCSV_Empty(t *testing.T) {
 
 	assert.Equal(t, "\n", out)
 }
+
+func TestFormatCompactTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty input", in: "", want: ""},
+		{name: "nanoseconds since epoch", in: "1700000000000000000", want: "22:13:20"},
+		{name: "rfc3339 utc", in: "2024-05-19T07:08:09Z", want: "07:08:09"},
+		{name: "rfc3339 with offset is normalised to utc", in: "2024-05-19T09:08:09+02:00", want: "07:08:09"},
+		{name: "unparseable falls back to input", in: "not-a-timestamp", want: "not-a-timestamp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatCompactTimestamp(tt.in))
+		})
+	}
+}
+
+func TestSeverityChar(t *testing.T) {
+	tests := []struct {
+		sev  int
+		want string
+	}{
+		{sev: 0, want: "D"},
+		{sev: 1, want: "D"},
+		{sev: 2, want: "D"},
+		{sev: 3, want: "I"},
+		{sev: 4, want: "W"},
+		{sev: 5, want: "E"},
+		{sev: 6, want: "F"},
+		{sev: 9, want: "F"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, severityChar(tt.sev), "severity %d", tt.sev)
+	}
+}

--- a/internal/cli/pager.go
+++ b/internal/cli/pager.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// defaultPager is used when the PAGER env var is unset. `-R` preserves ANSI
+// color sequences and `-F` quits if output fits on one screen.
+const defaultPager = "less -RF"
+
+// pagerProcess tracks an active pager subprocess and the original stdout so it
+// can be restored when the pager exits.
+type pagerProcess struct {
+	cmd            *exec.Cmd
+	pipeWriter     *os.File
+	originalStdout *os.File
+	stopped        bool
+}
+
+// startPager spawns a pager subprocess and redirects os.Stdout to it. Returns
+// nil if no pager is configured, stdout is not a TTY, or spawning fails.
+// Callers must invoke stop() before the program exits.
+func startPager() *pagerProcess {
+	if !IsTTY() {
+		return nil
+	}
+
+	pagerCmd := strings.TrimSpace(os.Getenv("PAGER"))
+	if pagerCmd == "" {
+		pagerCmd = defaultPager
+	}
+
+	parts := strings.Fields(pagerCmd)
+	if len(parts) == 0 {
+		return nil
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil
+	}
+
+	cmd := exec.Command(parts[0], parts[1:]...)
+	cmd.Stdin = r
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		_ = r.Close()
+		_ = w.Close()
+		return nil
+	}
+
+	// The pager owns the read end now.
+	_ = r.Close()
+
+	original := os.Stdout
+	os.Stdout = w
+
+	return &pagerProcess{
+		cmd:            cmd,
+		pipeWriter:     w,
+		originalStdout: original,
+	}
+}
+
+// stop closes the write end of the pipe (causing the pager to exit when it
+// finishes displaying) and waits for the pager to finish before returning.
+// Safe to call multiple times.
+func (p *pagerProcess) stop() {
+	if p == nil || p.stopped {
+		return
+	}
+	p.stopped = true
+	_ = p.pipeWriter.Close()
+	os.Stdout = p.originalStdout
+	_ = p.cmd.Wait()
+}

--- a/internal/cli/pager_test.go
+++ b/internal/cli/pager_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartPager_SkipsWhenNotTTY verifies the pager is a no-op when stdout is
+// not a terminal. Tests run with stdout redirected, so this is the common case.
+func TestStartPager_SkipsWhenNotTTY(t *testing.T) {
+	previous := IsTTY
+	IsTTY = func() bool { return false }
+	defer func() { IsTTY = previous }()
+
+	assert.Nil(t, startPager())
+}
+
+// TestStartPager_PipesStdoutThroughPager exercises the full pipeline by
+// pointing PAGER at `cat`, which behaves as a transparent pager: anything
+// written to os.Stdout while the pager is active reappears on the original
+// stdout once stop() finishes.
+func TestStartPager_PipesStdoutThroughPager(t *testing.T) {
+	previousTTY := IsTTY
+	IsTTY = func() bool { return true }
+	defer func() { IsTTY = previousTTY }()
+
+	t.Setenv("PAGER", "cat")
+
+	originalStdout := os.Stdout
+	captureR, captureW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = captureW
+
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	pager := startPager()
+	require.NotNil(t, pager)
+	require.NotEqual(t, captureW, os.Stdout, "startPager should swap os.Stdout for the pager pipe")
+
+	fmt.Fprint(os.Stdout, "hello via pager\n")
+
+	pager.stop()
+	require.NoError(t, captureW.Close())
+
+	got, err := io.ReadAll(captureR)
+	require.NoError(t, err)
+	assert.Equal(t, "hello via pager\n", string(got))
+	assert.Equal(t, captureW, os.Stdout, "stop() should restore the original stdout")
+}
+
+// TestPagerStop_Idempotent ensures stop() can be called safely after the pager
+// has already been torn down (e.g. once via errors.BeforeExit and once via the
+// deferred cleanup in Execute).
+func TestPagerStop_Idempotent(t *testing.T) {
+	previousTTY := IsTTY
+	IsTTY = func() bool { return true }
+	defer func() { IsTTY = previousTTY }()
+
+	t.Setenv("PAGER", "cat")
+
+	originalStdout := os.Stdout
+	_, captureW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = captureW
+	defer func() { os.Stdout = originalStdout }()
+
+	pager := startPager()
+	require.NotNil(t, pager)
+
+	pager.stop()
+	assert.NotPanics(t, func() { pager.stop() })
+}
+
+// TestPagerStop_NilReceiver guards against panicking when no pager was started.
+func TestPagerStop_NilReceiver(t *testing.T) {
+	var p *pagerProcess
+	assert.NotPanics(t, func() { p.stop() })
+}

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -42,7 +42,7 @@ func init() {
 	queryCmd.Flags().IntVar(&queryCount, "count", 10, "Number of log records to retrieve (1-5000)")
 	queryCmd.Flags().StringVar(&queryMode, "mode", "", "Display mode: head or tail")
 	queryCmd.Flags().StringVar(&queryColumns, "columns", "", "Comma-separated list of columns to display")
-	queryCmd.Flags().StringVar(&queryOutput, "output", "multiline", "Output format: multiline|singleline|csv|json|json-pretty")
+	queryCmd.Flags().StringVar(&queryOutput, "output", "multiline", "Output format: multiline|singleline|compact|csv|json|json-pretty")
 	queryCmd.Flags().StringVar(&queryFields, "fields", "", "Comma-separated fields to include in JSON output (e.g., timestamp,message,severity)")
 }
 
@@ -134,6 +134,11 @@ func runQuery(cmd *cobra.Command, args []string) {
 			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
 		}
 		outputSingleLine(result.Matches)
+	case "compact":
+		if queryFields != "" {
+			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
+		}
+		outputCompact(result.Matches)
 	default:
 		if queryFields != "" {
 			logging.Warn("--fields is only supported with json/json-pretty output, ignoring")
@@ -234,6 +239,12 @@ func outputSingleLine(events []client.LogEvent) {
 			fmt.Printf(" [%s]", strings.Join(attrs, ", "))
 		}
 		fmt.Println()
+	}
+}
+
+func outputCompact(events []client.LogEvent) {
+	for _, event := range events {
+		fmt.Printf("%s %s %s\n", formatCompactTimestamp(event.Timestamp), severityChar(event.Severity), event.Message)
 	}
 }
 

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/andreagrandi/logbasset/internal/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputCompact(t *testing.T) {
+	events := []client.LogEvent{
+		{Timestamp: "1700000000000000000", Severity: 3, Message: "service ready"},
+		{Timestamp: "1700000001000000000", Severity: 5, Message: "boom"},
+		{Timestamp: "not-a-time", Severity: 0, Message: "fallback"},
+	}
+
+	out := captureStdout(t, func() {
+		outputCompact(events)
+	})
+
+	expected := "22:13:20 I service ready\n" +
+		"22:13:21 E boom\n" +
+		"not-a-time D fallback\n"
+	assert.Equal(t, expected, out)
+}
+
+func TestOutputCompact_Empty(t *testing.T) {
+	out := captureStdout(t, func() {
+		outputCompact(nil)
+	})
+	assert.Empty(t, out)
+}
+
+func TestOutputTailCompact(t *testing.T) {
+	event := client.LogEvent{
+		Timestamp: "1700000000000000000",
+		Severity:  4,
+		Message:   "warning ahead",
+	}
+
+	out := captureStdout(t, func() {
+		outputTailCompact(event)
+	})
+
+	assert.Equal(t, "22:13:20 W warning ahead\n", out)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,9 @@ var (
 	flagLogLevel    string
 	flagTimeout     time.Duration
 	flagErrorFormat string
+	flagPager       bool
+
+	activePager *pagerProcess
 )
 
 var rootCmd = &cobra.Command{
@@ -61,7 +64,15 @@ The following commands are currently supported:
 			return err
 		}
 
-		return cfg.Validate()
+		if err := cfg.Validate(); err != nil {
+			return err
+		}
+
+		if flagPager {
+			activePager = startPager()
+		}
+
+		return nil
 	},
 }
 
@@ -73,6 +84,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagLogLevel, "log-level", "info", "Log level (debug|info|warn|error)")
 	rootCmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", 30*time.Second, "Request timeout (e.g., 30s, 2m, 1h)")
 	rootCmd.PersistentFlags().StringVar(&flagErrorFormat, "error-format", "text", "Error output format: text|json")
+	rootCmd.PersistentFlags().BoolVar(&flagPager, "pager", false, "Pipe output through $PAGER (default 'less -RF') when stdout is a terminal")
 
 	rootCmd.AddCommand(queryCmd)
 	rootCmd.AddCommand(powerQueryCmd)
@@ -85,6 +97,10 @@ func init() {
 }
 
 func Execute() error {
+	errors.BeforeExit = func() {
+		activePager.stop()
+	}
+	defer activePager.stop()
 	return rootCmd.Execute()
 }
 

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -100,7 +100,7 @@ var schemas = map[string]commandSchema{
 			{Name: "count", Type: "integer", Required: false, Default: 10, Description: "Number of log records (1-5000)"},
 			{Name: "mode", Type: "string", Required: false, Enum: []string{"head", "tail"}, Description: "Display mode"},
 			{Name: "columns", Type: "string", Required: false, Description: "Comma-separated list of columns"},
-			{Name: "output", Type: "string", Required: false, Default: "multiline", Enum: []string{"multiline", "singleline", "csv", "json", "json-pretty", "messageonly"}, Description: "Output format"},
+			{Name: "output", Type: "string", Required: false, Default: "multiline", Enum: []string{"multiline", "singleline", "compact", "csv", "json", "json-pretty", "messageonly"}, Description: "Output format"},
 			{Name: "fields", Type: "string", Required: false, Description: "Comma-separated fields to include in JSON output (e.g., timestamp,message,severity)"},
 		},
 		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
@@ -167,7 +167,7 @@ var schemas = map[string]commandSchema{
 		},
 		Flags: []paramSchema{
 			{Name: "lines", Type: "integer", Required: false, Default: 10, Description: "Number of previous lines to show (-n)"},
-			{Name: "output", Type: "string", Required: false, Default: "messageonly", Enum: []string{"messageonly", "multiline", "singleline", "json"}, Description: "Output format"},
+			{Name: "output", Type: "string", Required: false, Default: "messageonly", Enum: []string{"messageonly", "multiline", "singleline", "compact", "json"}, Description: "Output format"},
 		},
 		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
 	},

--- a/internal/cli/tail.go
+++ b/internal/cli/tail.go
@@ -31,7 +31,7 @@ var (
 
 func init() {
 	tailCmd.Flags().IntVarP(&tailLines, "lines", "n", 10, "Output the previous K lines when starting the tail")
-	tailCmd.Flags().StringVar(&tailOutput, "output", "messageonly", "Output format: multiline|singleline|messageonly|json")
+	tailCmd.Flags().StringVar(&tailOutput, "output", "messageonly", "Output format: multiline|singleline|compact|messageonly|json")
 }
 
 func runTail(cmd *cobra.Command, args []string) {
@@ -97,6 +97,8 @@ func runTail(cmd *cobra.Command, args []string) {
 			outputTailMultiLine(event)
 		case "singleline":
 			outputTailSingleLine(event)
+		case "compact":
+			outputTailCompact(event)
 		case "json":
 			outputTailJSON(event)
 		default:
@@ -115,6 +117,10 @@ func outputTailJSON(event client.LogEvent) {
 
 func outputTailMessageOnly(event client.LogEvent) {
 	fmt.Println(event.Message)
+}
+
+func outputTailCompact(event client.LogEvent) {
+	fmt.Printf("%s %s %s\n", formatCompactTimestamp(event.Timestamp), severityChar(event.Severity), event.Message)
 }
 
 func outputTailSingleLine(event client.LogEvent) {

--- a/internal/cli/validation_test.go
+++ b/internal/cli/validation_test.go
@@ -84,6 +84,13 @@ func TestValidationIntegration(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name: "compact output is valid",
+			params: validation.QueryValidationParams{
+				Output: "compact",
+			},
+			wantError: false,
+		},
+		{
 			name: "invalid priority",
 			params: validation.QueryValidationParams{
 				Priority: "medium",

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -12,6 +12,17 @@ import (
 // OutputJSON controls whether errors are emitted as JSON on stderr.
 var OutputJSON bool
 
+// BeforeExit, if set, is invoked just before HandleErrorAndExit calls os.Exit.
+// Use it to flush buffers or tear down subprocesses (e.g. a pager) that would
+// otherwise be skipped because os.Exit does not run deferred functions.
+var BeforeExit func()
+
+func runBeforeExit() {
+	if BeforeExit != nil {
+		BeforeExit()
+	}
+}
+
 type ErrorType string
 
 const (
@@ -191,6 +202,7 @@ func NewContextError(message string, cause error) *LogBassetError {
 
 func HandleErrorAndExit(err error) {
 	if err == nil {
+		runBeforeExit()
 		os.Exit(ExitSuccess)
 	}
 
@@ -203,6 +215,7 @@ func HandleErrorAndExit(err error) {
 				"exit_code":  logbassetErr.GetExitCode(),
 			}).Error(logbassetErr.Error())
 		}
+		runBeforeExit()
 		os.Exit(logbassetErr.GetExitCode())
 	}
 
@@ -216,5 +229,6 @@ func HandleErrorAndExit(err error) {
 	} else {
 		logging.Error(err.Error())
 	}
+	runBeforeExit()
 	os.Exit(ExitGeneral)
 }

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -31,7 +31,7 @@ func DefaultConfig() *ValidationConfig {
 		MaxBuckets:      5000,
 		MaxFacetCount:   1000,
 		MaxTailLines:    10000,
-		ValidOutputs:    []string{"multiline", "singleline", "csv", "json", "json-pretty", "messageonly"},
+		ValidOutputs:    []string{"multiline", "singleline", "compact", "csv", "json", "json-pretty", "messageonly"},
 		ValidPriorities: []string{"high", "low"},
 		ValidModes:      []string{"head", "tail"},
 	}


### PR DESCRIPTION
## Summary
- Add `compact` output format for `query` and `tail` (`HH:MM:SS <sev> <msg>` per line) for scanning large result sets.
- Add global `--pager` flag that pipes stdout through `$PAGER` (default `less -RF`) when stdout is a TTY; JSON/CSV behaviour is untouched when redirected to files.
- Wire pager teardown into `errors.HandleErrorAndExit` through a new `errors.BeforeExit` hook so output is flushed even on `os.Exit` paths.
- Document both the new mode and pager integration in README; add CHANGELOG entry.

Closes #40

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` is clean
- [x] `logbasset query --help` and `logbasset tail --help` advertise the new `compact` value and `--pager` flag
- [ ] Manual: run a real query against Scalyr with `--output compact` and with `--pager` to confirm interactive paging works