### PR TITLE
Add ticket/issue/bug workflow to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,14 +23,13 @@ gh issue create --repo andreagrandi/logbasset \
   --title "<concise title>" \
   --body "<description>" \
   --label "logbasset" \
-  --label "area:<area>"
+  --label "<area>"
 ```
 
 - Always apply the `logbasset` label — every work item in this repo carries it.
-- Add the matching `area:<area>` label when one exists: `area:feature`,
-  `area:ux`, `area:agent`, `area:docs`, `area:security`, `area:testing`,
-  `area:release`. The `Reliability` and `Packaging` areas have no label; for
-  those, set only the project Area field (step 3).
+- Add the matching area label when one exists: `feature`, `ux`, `agent`,
+  `docs`, `security`, `testing`, `release`. The `Reliability` and `Packaging`
+  areas have no label; for those, set only the project Area field (step 3).
 - Add a type label when it fits: `bug` (bug report), `enhancement` (feature
   request), or `documentation` (docs-only work).
 
@@ -61,7 +60,7 @@ gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAAm1584BYDlZ \
   --field-id PVTSSF_lAHOAAm1584BYDlZzhTMDck \
   --single-select-option-id <priority-option-id>
 
-# Area — match the area:<area> label from step 1
+# Area — match the area label from step 1
 gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAAm1584BYDlZ \
   --field-id PVTSSF_lAHOAAm1584BYDlZzhTMDco \
   --single-select-option-id <area-option-id>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,71 @@ Before making code or documentation changes in this repo:
 
 Do not start work from an old feature branch unless the user explicitly asks to continue that branch.
 
+## Adding a Ticket, Issue, or Bug
+
+When the user asks to add a "ticket", "issue", or "bug" to this repo, all of the
+steps below are required — creating the GitHub issue alone is not enough.
+
+**1. Create the issue** with the repo label and an area label:
+
+```bash
+gh issue create --repo andreagrandi/logbasset \
+  --title "<concise title>" \
+  --body "<description>" \
+  --label "logbasset" \
+  --label "area:<area>"
+```
+
+- Always apply the `logbasset` label — every work item in this repo carries it.
+- Add the matching `area:<area>` label when one exists: `area:feature`,
+  `area:ux`, `area:agent`, `area:docs`, `area:security`, `area:testing`,
+  `area:release`. The `Reliability` and `Packaging` areas have no label; for
+  those, set only the project Area field (step 3).
+- Add a type label when it fits: `bug` (bug report), `enhancement` (feature
+  request), or `documentation` (docs-only work).
+
+**2. Add the issue to the "CLI Tools" project** and capture the item ID
+(https://github.com/users/andreagrandi/projects/1):
+
+```bash
+ITEM_ID=$(gh project item-add 1 --owner andreagrandi \
+  --url <issue-url> --format json --jq .id)
+```
+
+**3. Set Priority, Area, and Status** on the project item. The project and
+field IDs are identical for every repo on this board:
+
+- Project ID: `PVT_kwHOAAm1584BYDlZ`
+- Priority — field `PVTSSF_lAHOAAm1584BYDlZzhTMDck`:
+  High `ed3787e3`, Medium `3e3ea407`, Low `994234f4`
+- Area — field `PVTSSF_lAHOAAm1584BYDlZzhTMDco`:
+  Reliability `6595432d`, Packaging `6895c50a`, UX `2bc024bb`,
+  Testing `0d5bc016`, Feature `6390f97d`, Agent `3a2d6f7e`,
+  Docs `f5c50514`, Security `062d12a3`, Release `b344aeab`
+- Status — field `PVTSSF_lAHOAAm1584BYDlZzhTMDNQ`:
+  Todo `f75ad846`, In Progress `47fc9ee4`, Done `98236657`
+
+```bash
+# Priority — always set it
+gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAAm1584BYDlZ \
+  --field-id PVTSSF_lAHOAAm1584BYDlZzhTMDck \
+  --single-select-option-id <priority-option-id>
+
+# Area — match the area:<area> label from step 1
+gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAAm1584BYDlZ \
+  --field-id PVTSSF_lAHOAAm1584BYDlZzhTMDco \
+  --single-select-option-id <area-option-id>
+
+# Status — new tickets start as Todo
+gh project item-edit --id "$ITEM_ID" --project-id PVT_kwHOAAm1584BYDlZ \
+  --field-id PVTSSF_lAHOAAm1584BYDlZzhTMDNQ \
+  --single-select-option-id f75ad846
+```
+
+If the user does not state a priority or area, ask before creating the issue.
+Follow the conventions of existing project issues — do not invent new labels or
+fields.
+
 ## When Adding User-Facing Features
 
 Any change that adds, renames, or removes a flag, command, output format, or


### PR DESCRIPTION
## Summary

Adds an **Adding a Ticket, Issue, or Bug** section to AGENTS.md so future agent
sessions follow a consistent workflow when asked to file a ticket, issue, or bug.

The documented workflow covers all required steps:

1. Create the GitHub issue with the repo label and a matching `area:*` label.
2. Add the issue to the [CLI Tools project](https://github.com/users/andreagrandi/projects/1).
3. Set the Priority, Area, and Status project fields.

It includes the project ID and the field/option IDs so the steps can be run
directly without looking them up.

## Notes

- Docs-only change; no code or behaviour affected.
- AGENTS.md is symlinked from CLAUDE.md, so both pick up the change.