### PR TITLE
Expand agent context and machine-readable command metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- `schema` now reports per-command `examples` and a `read_only` flag, and accepts `schema global` for the flags shared by every command (#41)
+- Agent context (`context`) gained Common Workflows and Safety and Cost Guidance sections (#41)
 - `compact` output format for `query` and `tail` showing one event per line as `HH:MM:SS <severity> <message>` for scanning large result sets (#40)
 - `--pager` global flag that pipes output through `$PAGER` (defaults to `less -RF`) when stdout is a terminal (#40)
 - Bounded retry with exponential backoff and jitter for transient network failures and 5xx responses; honor `Retry-After` on 429 throttling (#39)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,7 @@ Server URL (default `https://www.scalyr.com`):
 | `timeseries-query [filter]` | Retrieve timeseries data | none (filter optional) | `--start` |
 | `tail [filter]` | Live tail of logs | none (filter optional) | none |
 | `context` | Print this agent context document | none | none |
-| `schema [command]` | Print JSON schema for command inputs/outputs | none | none |
+| `schema [command]` | Print JSON schema for a command (pass `global` for shared flags) | none | none |
 
 ## Global Flags
 
@@ -39,6 +39,23 @@ Server URL (default `https://www.scalyr.com`):
 | `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
 | `--error-format` | string | `text` | Error output format: `text` or `json` |
 | `--pager` | bool | false | Pipe output through `$PAGER` (default `less -RF`) when stdout is a terminal |
+
+## Safety and Cost Guidance
+
+Every command is read-only — queries never create, modify, or delete data, so
+they are safe to run without confirmation. The `read_only` field in `schema`
+output reports this for each command.
+
+To keep queries fast and inexpensive:
+- Prefer narrow time ranges (`--start 1h` over `--start 7d`); only add
+  `--end NOW` when you need data right up to the current time.
+- Cap raw-record fetches with `--count`; the `query` default is 10.
+- Use `--priority low` for heavy or background queries so interactive queries
+  stay responsive. The default `high` is best for small, time-sensitive lookups.
+- Aggregations (`power-query`, `numeric-query`, `facet-query`,
+  `timeseries-query`) summarize wide ranges far more cheaply than fetching many
+  raw records with `query`.
+- Raise `--timeout` for queries over wide ranges; the default is 30s.
 
 ## Flags That Do NOT Exist
 
@@ -96,6 +113,23 @@ Use `--error-format json` to get machine-readable errors on stderr:
 ## TTY Auto-Detection
 
 When stdout is not a TTY (piped to another program), the default output format automatically switches to `json`. This can be overridden with an explicit `--output` flag.
+
+## Common Workflows
+
+### Investigate an error spike
+1. Find when errors occurred, bucketed by hour:
+   `logbasset numeric-query 'severity="error"' --function count --start 24h --buckets 24 --output json`
+2. Read sample errors from the affected window:
+   `logbasset query 'severity="error"' --start 2h --count 50 --output json`
+3. Group errors by host to localize the cause:
+   `logbasset power-query 'severity="error" | group count by serverHost' --start 2h --output json`
+
+### Trace a request or correlation ID
+Pass the identifier as a quoted text filter:
+`logbasset query '"req-abc123"' --start 24h --end NOW --output json`
+
+### Rank the most common values of a field
+`logbasset facet-query '*' uriPath --start 24h --count 20 --output json`
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.1
 require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -22,7 +23,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextEmbedMatchesContextMd(t *testing.T) {
+	onDisk, err := os.ReadFile("../../CONTEXT.md")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(onDisk), contextContent,
+		"CONTEXT.md and internal/cli/context_embed.md must be byte-identical")
+}
+
+func TestContextCommandOutput(t *testing.T) {
+	out := captureStdout(t, func() {
+		contextCmd.Run(contextCmd, nil)
+	})
+
+	assert.Equal(t, contextContent, out)
+
+	requiredSections := []string{
+		"## Commands",
+		"## Global Flags",
+		"## Safety and Cost Guidance",
+		"## Common Workflows",
+		"## Output Formats",
+		"## Exit Codes",
+		"## Examples",
+	}
+	for _, section := range requiredSections {
+		assert.Contains(t, out, section, "agent context is missing section %q", section)
+	}
+}
+
+func TestSchemaCommandListMatchesSchemas(t *testing.T) {
+	listed := make(map[string]bool)
+	for _, c := range getCommandList() {
+		assert.NotEmpty(t, c.Description, "command %q has no description", c.Name)
+		_, ok := schemas[c.Name]
+		assert.True(t, ok, "command %q is listed but has no schema entry", c.Name)
+		listed[c.Name] = true
+	}
+
+	for name := range schemas {
+		assert.True(t, listed[name], "schema %q exists but is not in the command list", name)
+	}
+}
+
+func TestSchemaOutputIsValidJSON(t *testing.T) {
+	listOut := captureStdout(t, func() {
+		runSchema(schemaCmd, nil)
+	})
+	assert.True(t, json.Valid([]byte(listOut)), "schema command list is not valid JSON")
+
+	var summaries []commandSummary
+	require.NoError(t, json.Unmarshal([]byte(listOut), &summaries))
+	assert.Len(t, summaries, len(getCommandList()))
+
+	for name := range schemas {
+		out := captureStdout(t, func() {
+			runSchema(schemaCmd, []string{name})
+		})
+		assert.True(t, json.Valid([]byte(out)), "schema %q is not valid JSON", name)
+
+		var schema commandSchema
+		require.NoError(t, json.Unmarshal([]byte(out), &schema), "schema %q failed to unmarshal", name)
+		assert.Equal(t, name, schema.Command)
+		assert.True(t, schema.ReadOnly, "schema %q must report read_only", name)
+	}
+}
+
+func TestRunnableCommandSchemasHaveExamples(t *testing.T) {
+	for name, schema := range schemas {
+		if name == "global" {
+			continue
+		}
+		assert.NotEmpty(t, schema.Examples, "command %q schema has no examples", name)
+	}
+}
+
+// TestSchemaFlagsMatchCobraDefinitions guards against schema drift: every flag a
+// command actually accepts must be described by `schema`, and vice versa.
+func TestSchemaFlagsMatchCobraDefinitions(t *testing.T) {
+	runnable := map[string]*cobra.Command{
+		"query":            queryCmd,
+		"power-query":      powerQueryCmd,
+		"numeric-query":    numericQueryCmd,
+		"facet-query":      facetQueryCmd,
+		"timeseries-query": timeseriesQueryCmd,
+		"tail":             tailCmd,
+	}
+
+	for name, cmd := range runnable {
+		schema, ok := schemas[name]
+		require.True(t, ok, "no schema for command %q", name)
+
+		schemaFlags := make(map[string]bool)
+		for _, f := range schema.Flags {
+			schemaFlags[f.Name] = true
+		}
+
+		cobraFlags := make(map[string]bool)
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Name == "help" {
+				return
+			}
+			cobraFlags[f.Name] = true
+		})
+
+		for flag := range cobraFlags {
+			assert.True(t, schemaFlags[flag],
+				"command %q defines flag %q but `schema %s` does not describe it", name, flag, name)
+		}
+		for flag := range schemaFlags {
+			assert.True(t, cobraFlags[flag],
+				"`schema %s` describes flag %q that command %q does not define", name, flag, name)
+		}
+	}
+}
+
+func TestGlobalSchemaMatchesPersistentFlags(t *testing.T) {
+	schema, ok := schemas["global"]
+	require.True(t, ok, "missing 'global' schema entry")
+
+	schemaFlags := make(map[string]bool)
+	for _, f := range schema.Flags {
+		schemaFlags[f.Name] = true
+	}
+
+	cobraFlags := make(map[string]bool)
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		cobraFlags[f.Name] = true
+	})
+
+	for flag := range cobraFlags {
+		assert.True(t, schemaFlags[flag],
+			"persistent flag %q is not described by `schema global`", flag)
+	}
+	for flag := range schemaFlags {
+		assert.True(t, cobraFlags[flag],
+			"`schema global` describes flag %q that is not a persistent flag", flag)
+	}
+}

--- a/internal/cli/context_embed.md
+++ b/internal/cli/context_embed.md
@@ -25,7 +25,7 @@ Server URL (default `https://www.scalyr.com`):
 | `timeseries-query [filter]` | Retrieve timeseries data | none (filter optional) | `--start` |
 | `tail [filter]` | Live tail of logs | none (filter optional) | none |
 | `context` | Print this agent context document | none | none |
-| `schema [command]` | Print JSON schema for command inputs/outputs | none | none |
+| `schema [command]` | Print JSON schema for a command (pass `global` for shared flags) | none | none |
 
 ## Global Flags
 
@@ -39,6 +39,23 @@ Server URL (default `https://www.scalyr.com`):
 | `--timeout` | duration | `30s` | Request timeout (e.g., `30s`, `2m`) |
 | `--error-format` | string | `text` | Error output format: `text` or `json` |
 | `--pager` | bool | false | Pipe output through `$PAGER` (default `less -RF`) when stdout is a terminal |
+
+## Safety and Cost Guidance
+
+Every command is read-only — queries never create, modify, or delete data, so
+they are safe to run without confirmation. The `read_only` field in `schema`
+output reports this for each command.
+
+To keep queries fast and inexpensive:
+- Prefer narrow time ranges (`--start 1h` over `--start 7d`); only add
+  `--end NOW` when you need data right up to the current time.
+- Cap raw-record fetches with `--count`; the `query` default is 10.
+- Use `--priority low` for heavy or background queries so interactive queries
+  stay responsive. The default `high` is best for small, time-sensitive lookups.
+- Aggregations (`power-query`, `numeric-query`, `facet-query`,
+  `timeseries-query`) summarize wide ranges far more cheaply than fetching many
+  raw records with `query`.
+- Raise `--timeout` for queries over wide ranges; the default is 30s.
 
 ## Flags That Do NOT Exist
 
@@ -96,6 +113,23 @@ Use `--error-format json` to get machine-readable errors on stderr:
 ## TTY Auto-Detection
 
 When stdout is not a TTY (piped to another program), the default output format automatically switches to `json`. This can be overridden with an explicit `--output` flag.
+
+## Common Workflows
+
+### Investigate an error spike
+1. Find when errors occurred, bucketed by hour:
+   `logbasset numeric-query 'severity="error"' --function count --start 24h --buckets 24 --output json`
+2. Read sample errors from the affected window:
+   `logbasset query 'severity="error"' --start 2h --count 50 --output json`
+3. Group errors by host to localize the cause:
+   `logbasset power-query 'severity="error" | group count by serverHost' --start 2h --output json`
+
+### Trace a request or correlation ID
+Pass the identifier as a quoted text filter:
+`logbasset query '"req-abc123"' --start 24h --end NOW --output json`
+
+### Rank the most common values of a field
+`logbasset facet-query '*' uriPath --start 24h --count 20 --output json`
 
 ## Examples
 

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/andreagrandi/logbasset/internal/errors"
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ var schemaPretty bool
 var schemaCmd = &cobra.Command{
 	Use:   "schema [command]",
 	Short: "Print JSON schema for command inputs and outputs",
-	Long:  "Prints JSON schema describing a command's parameters, types, defaults, and valid values. With no arguments, lists all commands.",
+	Long:  "Prints JSON schema describing a command's parameters, types, defaults, valid values, and examples. With no arguments, lists all commands. Pass 'global' for the flags shared by every command.",
 	Args:  cobra.MaximumNArgs(1),
 	Run:   runSchema,
 }
@@ -38,9 +39,11 @@ type paramSchema struct {
 
 type commandSchema struct {
 	Command    string        `json:"command"`
+	ReadOnly   bool          `json:"read_only"`
 	Args       []paramSchema `json:"args,omitempty"`
 	Flags      []paramSchema `json:"flags"`
 	OutputKeys []string      `json:"output_keys,omitempty"`
+	Examples   []string      `json:"examples,omitempty"`
 }
 
 func runSchema(cmd *cobra.Command, args []string) {
@@ -51,9 +54,13 @@ func runSchema(cmd *cobra.Command, args []string) {
 
 	schema, ok := schemas[args[0]]
 	if !ok {
+		var names []string
+		for _, c := range getCommandList() {
+			names = append(names, c.Name)
+		}
 		errors.HandleErrorAndExit(errors.NewUsageError(
 			fmt.Sprintf("unknown command: %s", args[0]),
-			fmt.Errorf("valid commands: query, power-query, numeric-query, facet-query, timeseries-query, tail"),
+			fmt.Errorf("valid commands: %s", strings.Join(names, ", ")),
 		))
 	}
 
@@ -85,12 +92,27 @@ func getCommandList() []commandSummary {
 		{Name: "facet-query", Description: "Retrieve common values for a field"},
 		{Name: "timeseries-query", Description: "Retrieve timeseries data"},
 		{Name: "tail", Description: "Provide a live tail of a log"},
+		{Name: "global", Description: "Flags shared by every command (schema target only, not a runnable command)"},
+	}
+}
+
+func globalFlags() []paramSchema {
+	return []paramSchema{
+		{Name: "token", Type: "string", Required: false, Description: "API token (or scalyr_readlog_token env var)"},
+		{Name: "server", Type: "string", Required: false, Default: "https://www.scalyr.com", Description: "Scalyr server URL (or scalyr_server env var)"},
+		{Name: "verbose", Type: "boolean", Required: false, Default: false, Description: "Enable verbose output"},
+		{Name: "priority", Type: "string", Required: false, Default: "high", Enum: []string{"high", "low"}, Description: "Query priority; use 'low' for heavy or background queries"},
+		{Name: "log-level", Type: "string", Required: false, Default: "info", Enum: []string{"debug", "info", "warn", "error"}, Description: "Log level"},
+		{Name: "timeout", Type: "string", Required: false, Default: "30s", Description: "Request timeout (e.g., 30s, 2m)"},
+		{Name: "error-format", Type: "string", Required: false, Default: "text", Enum: []string{"text", "json"}, Description: "Error output format"},
+		{Name: "pager", Type: "boolean", Required: false, Default: false, Description: "Pipe output through $PAGER (default 'less -RF') when stdout is a terminal"},
 	}
 }
 
 var schemas = map[string]commandSchema{
 	"query": {
-		Command: "query",
+		Command:  "query",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
 		},
@@ -104,9 +126,14 @@ var schemas = map[string]commandSchema{
 			{Name: "fields", Type: "string", Required: false, Description: "Comma-separated fields to include in JSON output (e.g., timestamp,message,severity)"},
 		},
 		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
+		Examples: []string{
+			"logbasset query 'severity=\"error\"' --start 1h --count 100 --output json",
+			"logbasset query '\"req-abc123\"' --start 24h --end NOW --output json --fields timestamp,message",
+		},
 	},
 	"power-query": {
-		Command: "power-query",
+		Command:  "power-query",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "query", Type: "string", Required: true, Description: "PowerQuery expression"},
 		},
@@ -115,9 +142,13 @@ var schemas = map[string]commandSchema{
 			{Name: "end", Type: "string", Required: false, Description: "End time"},
 			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
 		},
+		Examples: []string{
+			"logbasset power-query 'severity=\"error\" | group count by serverHost' --start 1h --output json",
+		},
 	},
 	"numeric-query": {
-		Command: "numeric-query",
+		Command:  "numeric-query",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
 		},
@@ -129,9 +160,13 @@ var schemas = map[string]commandSchema{
 			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
 		},
 		OutputKeys: []string{"values"},
+		Examples: []string{
+			"logbasset numeric-query 'severity=\"error\"' --function count --start 24h --buckets 24 --output json",
+		},
 	},
 	"facet-query": {
-		Command: "facet-query",
+		Command:  "facet-query",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "filter", Type: "string", Required: true, Description: "Log filter expression"},
 			{Name: "field", Type: "string", Required: true, Description: "Field name to facet on"},
@@ -143,9 +178,13 @@ var schemas = map[string]commandSchema{
 			{Name: "output", Type: "string", Required: false, Default: "csv", Enum: []string{"csv", "json", "json-pretty"}, Description: "Output format"},
 		},
 		OutputKeys: []string{"value", "count"},
+		Examples: []string{
+			"logbasset facet-query '*' uriPath --start 24h --count 20 --output json",
+		},
 	},
 	"timeseries-query": {
-		Command: "timeseries-query",
+		Command:  "timeseries-query",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
 		},
@@ -159,9 +198,13 @@ var schemas = map[string]commandSchema{
 			{Name: "no-create-summaries", Type: "boolean", Required: false, Default: false, Description: "Don't create summaries"},
 		},
 		OutputKeys: []string{"values"},
+		Examples: []string{
+			"logbasset timeseries-query 'severity=\"error\"' --function count --start 24h --buckets 24 --output json",
+		},
 	},
 	"tail": {
-		Command: "tail",
+		Command:  "tail",
+		ReadOnly: true,
 		Args: []paramSchema{
 			{Name: "filter", Type: "string", Required: false, Description: "Log filter expression"},
 		},
@@ -170,5 +213,13 @@ var schemas = map[string]commandSchema{
 			{Name: "output", Type: "string", Required: false, Default: "messageonly", Enum: []string{"messageonly", "multiline", "singleline", "compact", "json"}, Description: "Output format"},
 		},
 		OutputKeys: []string{"timestamp", "severity", "message", "thread", "attributes"},
+		Examples: []string{
+			"logbasset tail 'severity=\"error\"' --lines 50 --output json",
+		},
+	},
+	"global": {
+		Command:  "global",
+		ReadOnly: true,
+		Flags:    globalFlags(),
 	},
 }


### PR DESCRIPTION
## Summary

Closes #41. Enriches the agent-facing `context` and `schema` surfaces so AI agents can discover common workflows, safety guidance, and richer command metadata.

- **`schema`**: each command schema now reports per-command `examples` and a `read_only` flag. A new `schema global` target exposes the 8 shared/persistent flags (`--timeout`, `--priority`, etc.), which were previously undiscoverable when inspecting a single command. The unknown-command error message is now derived from the command list so it cannot drift.
- **`context`** (`CONTEXT.md` + `internal/cli/context_embed.md`, kept byte-identical): adds a **Common Workflows** section (investigate an error spike, trace a request ID, rank field values) and a **Safety and Cost Guidance** section (read-only guarantee plus time-range/`--count`/`--priority`/`--timeout` cost advice).
- **Tests** (`internal/cli/agent_test.go`): new coverage for context/schema output stability — `CONTEXT.md` matches the embed file byte-for-byte, schema output is valid JSON for every command, and schema flag definitions are cross-checked against the cobra flag definitions in both directions (guards against future schema drift).
- **`CHANGELOG.md`**: entry under `[Unreleased]`.
- **`go.mod`**: `spf13/pflag` promoted to a direct dependency (used by the new test).

## Test plan

- [x] `go test ./...` passes
- [x] `gofmt -s -l .` reports no issues
- [x] `go vet ./...` passes
- [x] `logbasset schema global`, `logbasset schema query`, and `logbasset context` produce the expected output