### PR TITLE
Add install smoke tests for release artifacts and Homebrew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
     - name: Build
       run: make build
 
+    - name: Smoke test binary
+      run: ./scripts/smoke-test.sh bin/logbasset
+
     - name: Upload build artifact
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,9 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
           GORELEASER_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Smoke test release artifact
+        run: |
+          mkdir -p dist/smoke
+          tar -xzf dist/logbasset_Linux_x86_64.tar.gz -C dist/smoke
+          ./scripts/smoke-test.sh dist/smoke/logbasset

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,5 +74,7 @@ brews:
     license: "MIT"
     test: |
       system "#{bin}/logbasset --version"
+      system "#{bin}/logbasset --help"
+      system "#{bin}/logbasset schema"
     install: |
       bin.install "logbasset"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ client := cfg.GetClient()
 - `make test-verbose` - Run tests with verbose output
 - `make test-client` - Run tests for client package only
 - `make test-cli` - Run tests for CLI package only
+- `make smoke-test` - Smoke-test the built binary (no API credentials needed)
 - `make fmt` - Format code
 - `make vet` - Static analysis
 - `make lint` - Run linter (requires golangci-lint)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Install smoke tests (`scripts/smoke-test.sh`, `make smoke-test`) that verify built binaries and release artifacts respond to `--version`, `--help`, and no-credential commands; wired into CI and the release workflow, with an expanded Homebrew formula test block (#44)
 - README recipes for common log investigation workflows and a troubleshooting guide covering auth, time ranges, and empty results (#42)
 - CLI end-to-end tests covering docs examples and JSON/CSV/text output formats against mocked HTTP responses, with no real Scalyr credentials required (#43)
 - `schema` now reports per-command `examples` and a `read_only` flag, and accepts `schema global` for the flags shared by every command (#41)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean fmt vet lint
+.PHONY: build test smoke-test clean fmt vet lint
 
 # Build the binary
 build:
@@ -20,6 +20,10 @@ test-client:
 # Run tests for specific package
 test-cli:
 	go test ./internal/cli
+
+# Smoke-test the built binary (no API credentials required)
+smoke-test: build
+	./scripts/smoke-test.sh bin/logbasset
 
 # Format code
 fmt:
@@ -59,6 +63,7 @@ help:
 	@echo "  test-verbose - Run tests with verbose output"
 	@echo "  test-client  - Run client tests only"
 	@echo "  test-cli     - Run CLI tests only"
+	@echo "  smoke-test   - Smoke-test the built binary"
 	@echo "  fmt          - Format code"
 	@echo "  vet          - Run static analysis"
 	@echo "  lint         - Run linter"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ The binary will be created in the `bin/` directory.
 
 Download the latest binary from the [releases page](https://github.com/andreagrandi/logbasset/releases).
 
+### Verifying an Install
+
+After installing via any method, a quick credential-free smoke check confirms
+the binary works:
+
+```bash
+logbasset --version
+logbasset --help
+```
+
+If you cloned the repository, `make smoke-test` runs the full set of checks
+(version, help, and the no-credential `context` and `schema` commands) against
+the built binary. To smoke-test a Homebrew install, point the script at the
+installed binary:
+
+```bash
+scripts/smoke-test.sh "$(command -v logbasset)"
+```
+
+The Homebrew formula also ships a `brew test logbasset` block that runs the
+same checks automatically.
+
 ## Configuration
 
 You need to make your Scalyr API token available to the tool. LogBasset supports multiple configuration methods:
@@ -496,6 +518,9 @@ make build
 
 # Run tests
 make test
+
+# Smoke-test the built binary (no API credentials needed)
+make smoke-test
 
 # Build for multiple platforms
 make build-all

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Smoke-test a built logbasset binary or release artifact.
+# Exercises only commands that need no API credentials so it can run in CI
+# and against published archives. Exits non-zero on the first failed check.
+#
+# Usage: scripts/smoke-test.sh [path-to-binary]   (default: bin/logbasset)
+set -euo pipefail
+
+BINARY="${1:-bin/logbasset}"
+
+if [ ! -x "$BINARY" ]; then
+	echo "smoke-test: binary not found or not executable: $BINARY" >&2
+	exit 1
+fi
+
+CORE_COMMANDS=(query power-query numeric-query facet-query timeseries-query tail)
+
+fail() {
+	echo "smoke-test: FAIL - $1" >&2
+	exit 1
+}
+
+ok() {
+	echo "smoke-test: ok - $1"
+}
+
+run() {
+	local desc="$1"
+	shift
+	if "$@" >/dev/null 2>&1; then
+		ok "$desc"
+	else
+		fail "$desc"
+	fi
+}
+
+# --version prints a recognizable, non-empty version line.
+version_output="$("$BINARY" --version 2>&1)" || fail "--version exited non-zero"
+case "$version_output" in
+	"logbasset version "*) ok "--version ($version_output)" ;;
+	*) fail "--version output unexpected: $version_output" ;;
+esac
+
+# Top-level help lists every core command.
+help_output="$("$BINARY" --help 2>&1)" || fail "--help exited non-zero"
+for cmd in "${CORE_COMMANDS[@]}"; do
+	case "$help_output" in
+		*"$cmd"*) ;;
+		*) fail "--help missing command: $cmd" ;;
+	esac
+done
+ok "--help lists core commands"
+
+# Per-command help renders without error.
+for cmd in "${CORE_COMMANDS[@]}"; do
+	run "$cmd --help" "$BINARY" "$cmd" --help
+done
+
+# Commands that need no API credentials work end to end.
+run "context" "$BINARY" context
+run "schema" "$BINARY" schema
+run "completion bash" "$BINARY" completion bash
+
+echo "smoke-test: all checks passed for $BINARY"


### PR DESCRIPTION
## Summary

Adds credential-free install smoke tests so packaging regressions surface in CI and at release time instead of reaching users. Closes #44.

- **`scripts/smoke-test.sh`** — portable smoke test for a `logbasset` binary: checks `--version` output, that top-level `--help` lists every core command, per-command `--help`, and the no-auth `context`/`schema`/`completion` commands. Exits non-zero on the first failure.
- **`make smoke-test`** — builds then runs the script.
- **CI** (`ci.yml`) — smoke-tests `bin/logbasset` after `make build` on every PR/push, across all Go versions. This is the pre-merge gate.
- **Release** (`release.yml`) — extracts the published `logbasset_Linux_x86_64.tar.gz` and smoke-tests the actual artifact after GoReleaser, catching issues like broken version injection.
- **Homebrew** — expanded the GoReleaser formula `test` block from just `--version` to also cover `--help` and `schema`, so `brew test logbasset` verifies the formula automatically.
- Docs: README "Verifying an Install" section (with the manual Homebrew check), CHANGELOG `[Unreleased]` entry, AGENTS.md make-target list.

## Acceptance criteria

- Release artifacts are smoke-tested automatically (CI + release workflow).
- Homebrew path is verified automatically (`brew test`) and documented as a manual check.
- Smoke tests require no real API credentials.

## Test plan

- [x] `make smoke-test` passes locally
- [x] Smoke test exits non-zero against a deliberately broken binary
- [x] `make test`, `make vet`, `gofmt -s -l` clean
- [ ] CI smoke-test step passes on this PR
- [ ] Release workflow smoke-tests the published artifact on the next tag