### PR TITLE
Add installable agent skill for skills.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Binaries
 bin/
 dist/
-logbasset
+/logbasset
 
 # Go build cache
 .cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,11 @@ of these leaves the docs lying:
   affected command so `logbasset schema` reports the new state.
 - Help strings on the relevant `cobra.Command` flag definitions.
 
+The `skills/logbasset` agent skill is **not** on this list by design: it
+delegates to `logbasset context` and `logbasset schema` at runtime instead of
+restating commands or flags, so a CLI change can never make it stale. Keep it
+generic — do not add per-flag or per-command content to it.
+
 ## Project Structure
 LogBasset follows the standard Go project layout:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Installable agent skill (`skills/logbasset`) for [skills.sh](https://www.skills.sh/) that teaches coding agents when and how to use the CLI, delegating to `logbasset context` and `logbasset schema` for the live command reference
+
 ## v0.5.0 - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ scripts/smoke-test.sh "$(command -v logbasset)"
 The Homebrew formula also ships a `brew test logbasset` block that runs the
 same checks automatically.
 
+## Use with AI Coding Agents
+
+LogBasset ships an installable [agent skill](https://www.skills.sh/) so your
+coding agent knows when and how to reach for the CLI. Install it alongside the
+binary:
+
+```bash
+npx skills add andreagrandi/logbasset
+```
+
+The skill teaches the agent to use `logbasset` for Scalyr/DataSet log
+investigations and to load the live command reference (`logbasset context`,
+`logbasset schema`) instead of guessing flags. It works with any
+[skills.sh-supported agent](https://www.skills.sh/) (Claude Code, Codex,
+Cursor, and others). The binary must be installed separately (see above).
+
 ## Configuration
 
 You need to make your Scalyr API token available to the tool. LogBasset supports multiple configuration methods:

--- a/skills/logbasset/SKILL.md
+++ b/skills/logbasset/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: logbasset
+description: Query, search, aggregate, or live-tail Scalyr/DataSet logs from the command line with the logbasset CLI. Use when the user wants to investigate logs, find events by ID or field, count or aggregate log data over a time range, or live-tail a log.
+---
+
+# logbasset
+
+`logbasset` is a **read-only** command-line tool for querying Scalyr/DataSet
+logs. It can search raw log records, run aggregations (counts, groupings,
+facets, time series), and live-tail a log. Nothing it does mutates data.
+
+This skill does not restate the command and flag reference, because the binary
+documents itself and stays current with the installed version. Load that
+reference at runtime instead of guessing.
+
+## Workflow
+
+Follow these steps in order:
+
+1. **Check the binary is installed.** Confirm `logbasset` is on `PATH` (e.g.
+   `logbasset --version`). If it is not found, stop and tell the user to
+   install it (`brew install andreagrandi/tap/logbasset`, or download from
+   https://github.com/andreagrandi/logbasset/releases) — do not attempt to
+   query without it.
+2. **Load the authoritative reference.** Run `logbasset context` to print the
+   current list of commands, flags, time formats, output formats, exit codes,
+   and worked workflows for the installed version. Treat this output as the
+   source of truth.
+3. **Confirm exact flags before composing a non-trivial query.** Run
+   `logbasset schema <command>` for a specific command's flags, enums, and
+   defaults, or `logbasset schema global` for the flags shared by every
+   command. Do not invent flags — `logbasset context` lists ones that look
+   plausible but do not exist.
+4. **Construct and run the query** using only flags confirmed from the steps
+   above.
+
+## Safety
+
+Every `logbasset` command is read-only — queries never create, modify, or
+delete data — so they are safe to run without asking the user for
+confirmation.
+
+## Keeping queries fast and inexpensive
+
+- Prefer narrow time ranges (`--start 1h` over `--start 7d`).
+- Cap raw-record fetches with `--count`.
+- Prefer aggregation commands over fetching many raw records when the user
+  wants counts, rates, or top values.
+- Use `--priority low` for heavy or background queries so interactive ones stay
+  responsive.
+
+For the exact flag names, output formats, and time syntax, always rely on
+`logbasset context` and `logbasset schema` rather than memory.


### PR DESCRIPTION
## Summary

Ships a canonical, public **logbasset** agent skill at `skills/logbasset/SKILL.md`, installable via [skills.sh](https://www.skills.sh/) (`npx skills add andreagrandi/logbasset`). The goal is to encourage users to install the skill alongside the binary so their coding agent knows *when* and *how* to reach for the CLI.

## Design

The skill is intentionally a **thin pointer, not a copy of the docs**:

- It does not restate commands or flags. Its runtime workflow is: check the binary is on `PATH`, then run `logbasset context` (authoritative reference) and `logbasset schema <command>` (exact flags) before composing a query.
- Because nothing in it is flag- or command-specific, a CLI change can never make it stale, and it stays out of the existing per-flag doc-sync checklist.
- Written in agent-neutral voice (no assumptions about a specific agent), since skills.sh installs to many agents (Claude Code, Codex, Cursor, and others).
- Includes a binary-presence preflight — the one thing the skill must own, since a missing binary can't be discovered by running `logbasset context`.

## Changes

- `skills/logbasset/SKILL.md` — new skill (pure pointer, delegates to `logbasset context` / `logbasset schema`).
- `README.md` — "Use with AI Coding Agents" section with the install command.
- `CHANGELOG.md` — `[Unreleased]` entry.
- `AGENTS.md` — note exempting the skill from the per-flag doc-sync checklist so contributors don't reintroduce drift.
- `.gitignore` — anchor the `logbasset` binary pattern to the repo root (`/logbasset`) so it no longer matches the `skills/logbasset/` directory. The root and `bin/` binaries remain ignored.

## Validation

`npx skills add . --list` discovers exactly one skill (`logbasset`) with the expected description, confirming the SKILL.md frontmatter is well-formed.